### PR TITLE
SignalR Optimizations: Type-Safe Communication and Performance Improvements

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -30,7 +30,7 @@ jobs:
     - name: Unit Tests
       run: dotnet test ./Projects/TutoProxy/TutoProxy.sln --no-build --verbosity normal
     - name: Perfomance Tests
-      run: ./Projects/TutoProxy/scripts/perf-test.sh tunnel -d 20
+      run: ./Projects/TutoProxy/scripts/perf-test.sh full -d 10
 
     - name: Publish
       run: |

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Perf Test: Full (baseline + tunnel)",
+            "label": "Perf Test: Full (Auto + Http + WebSocket)",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
             "args": ["full", "-d", "10"],
@@ -14,10 +14,10 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: Tunnel only",
+            "label": "Perf Test: Auto protocol",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["tunnel", "-d", "10"],
+            "args": ["auto", "-d", "10"],
             "group": "test",
             "presentation": {
                 "reveal": "always",
@@ -26,10 +26,10 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: Baseline only",
+            "label": "Perf Test: Http protocol (LongPolling)",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["baseline", "-d", "10"],
+            "args": ["http", "-d", "10"],
             "group": "test",
             "presentation": {
                 "reveal": "always",
@@ -38,10 +38,22 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: Tunnel (30s, 4 parallel)",
+            "label": "Perf Test: WebSocket protocol (fastest)",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["tunnel", "-d", "30", "-p", "4"],
+            "args": ["websocket", "-d", "10"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: WebSocket (30s, 4 parallel)",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["websocket", "-d", "30", "-p", "4"],
             "group": "test",
             "presentation": {
                 "reveal": "always",

--- a/Projects/TutoProxy/TuToProxy.Core/IClientHub.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/IClientHub.cs
@@ -1,8 +1,10 @@
+using System.Net.Sockets;
 using TuToProxy.Core.Models;
 
 namespace TuToProxy.Core {
     /// <summary>
-    /// Typed hub interface for server-to-client method calls.
+    /// Typed hub interface for server-to-client method calls (fire-and-forget).
+    /// Used by server's Hub&lt;IClientHub&gt;.
     /// Note: Methods returning values from client (InvokeAsync pattern)
     /// are not supported by typed hubs and use ClientMethods constants instead.
     /// </summary>
@@ -20,5 +22,30 @@ namespace TuToProxy.Core {
         public const string ConnectTcp = "ConnectTcp";
         public const string TcpRequest = "TcpRequest";
         public const string DisconnectTcp = "DisconnectTcp";
+    }
+
+    /// <summary>
+    /// Interface for client-to-server hub method calls.
+    /// Used by TypedSignalR.Client source generator on client side.
+    /// </summary>
+    public interface IServerHub {
+        Task UdpResponse(UdpDataResponseModel response);
+        Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered);
+        Task<int> TcpResponse(TcpDataResponseModel response);
+        Task<bool> DisconnectTcp(SocketAddressModel socketAddress);
+    }
+
+    /// <summary>
+    /// Interface for server-to-client method calls (receiver).
+    /// Used by TypedSignalR.Client source generator on client side.
+    /// Includes all methods including those with return values (client results).
+    /// </summary>
+    public interface IClientReceiver {
+        Task Errors(string message);
+        Task UdpRequest(UdpDataRequestModel request);
+        Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered);
+        Task<SocketError> ConnectTcp(SocketAddressModel socketAddress);
+        Task<int> TcpRequest(TcpDataRequestModel request);
+        Task<bool> DisconnectTcp(SocketAddressModel socketAddress);
     }
 }

--- a/Projects/TutoProxy/TuToProxy.Core/IClientHub.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/IClientHub.cs
@@ -1,0 +1,24 @@
+using TuToProxy.Core.Models;
+
+namespace TuToProxy.Core {
+    /// <summary>
+    /// Typed hub interface for server-to-client method calls.
+    /// Note: Methods returning values from client (InvokeAsync pattern)
+    /// are not supported by typed hubs and use ClientMethods constants instead.
+    /// </summary>
+    public interface IClientHub {
+        Task Errors(string message);
+        Task UdpRequest(UdpDataRequestModel request);
+        Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered);
+    }
+
+    /// <summary>
+    /// Method name constants for InvokeAsync calls (client results pattern).
+    /// Typed hubs don't support methods with return values from client.
+    /// </summary>
+    public static class ClientMethods {
+        public const string ConnectTcp = "ConnectTcp";
+        public const string TcpRequest = "TcpRequest";
+        public const string DisconnectTcp = "DisconnectTcp";
+    }
+}

--- a/Projects/TutoProxy/TuToProxy.Core/TransportProtocol.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/TransportProtocol.cs
@@ -1,0 +1,7 @@
+namespace TuToProxy.Core {
+    public enum TransportProtocol {
+        Auto,
+        Http,
+        WebSocket
+    }
+}

--- a/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
@@ -20,6 +20,7 @@ namespace TutoProxy.Server.CommandLine {
             var udpOption = PortsArgument.CreateOption("--udp", $"Tunneling ports, format like '--udp=700-900,65500'");
             Add(tcpOption);
             Add(udpOption);
+            Add(new Option<TransportProtocol>("--protocol", () => TransportProtocol.Auto, "Transport protocol: Auto, Http, WebSocket"));
             Add(new Option<bool>("--daemon", () => false, "Run as a daemon"));
             AddValidator((result) => {
                 try {
@@ -44,6 +45,7 @@ namespace TutoProxy.Server.CommandLine {
             public string? Id { get; set; }
             public PortsArgument? Udp { get; set; }
             public PortsArgument? Tcp { get; set; }
+            public TransportProtocol Protocol { get; set; }
             public bool? Daemon { get; set; }
 
             public Handler(
@@ -110,7 +112,7 @@ namespace TutoProxy.Server.CommandLine {
                         while(!cancellationToken.IsCancellationRequested) {
                             try {
                                 logStatus("connection to server...");
-                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id, cancellationToken);
+                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id, Protocol, cancellationToken);
 
                                 logStatus($"{connectionId}");
                                 break;

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -3,6 +3,7 @@ using System.Net.Sockets;
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Http.Connections;
 using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using TutoProxy.Client.Services;
@@ -10,7 +11,7 @@ using TuToProxy.Core;
 
 namespace TutoProxy.Client.Communication {
     public interface ISignalRClient : IDisposable {
-        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, CancellationToken cancellationToken);
+        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, CancellationToken cancellationToken);
         Task StopAsync();
         Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken);
         Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken);
@@ -51,7 +52,7 @@ namespace TutoProxy.Client.Communication {
         public void Dispose() {
         }
 
-        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, CancellationToken cancellationToken) {
+        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, CancellationToken cancellationToken) {
             Guard.NotNullOrEmpty(server, nameof(server));
             Guard.NotNull(tcpQuery ?? udpQuery, $"Tcp ?? Udp");
 
@@ -68,7 +69,14 @@ namespace TutoProxy.Client.Communication {
             ub.Query = query.ToString();
 
             connection = new HubConnectionBuilder()
-                 .WithUrl(ub.Uri)
+                 .WithUrl(ub.Uri, options => {
+                     if(protocol == TransportProtocol.WebSocket) {
+                         options.Transports = HttpTransportType.WebSockets;
+                         options.SkipNegotiation = true;
+                     } else if(protocol == TransportProtocol.Http) {
+                         options.Transports = HttpTransportType.LongPolling;
+                     }
+                 })
                  .WithAutomaticReconnect(new RetryPolicy(logger))
                  .AddMessagePackProtocol(config => {
                      config.SerializerOptions = MessagePackSerializerOptions.Standard

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -8,6 +8,8 @@ using Microsoft.AspNetCore.SignalR.Client;
 using Microsoft.Extensions.DependencyInjection;
 using TutoProxy.Client.Services;
 using TuToProxy.Core;
+using TuToProxy.Core.Models;
+using TypedSignalR.Client;
 
 namespace TutoProxy.Client.Communication {
     public interface ISignalRClient : IDisposable {
@@ -34,11 +36,74 @@ namespace TutoProxy.Client.Communication {
                 return TimeSpan.FromSeconds(Math.Min(retryContext.PreviousRetryCount + 1, 60));
             }
         }
+
+        class ClientReceiver : IClientReceiver {
+            readonly ILogger logger;
+            readonly IClientsService clientsService;
+            readonly ISignalRClient signalRClient;
+            readonly Func<Task> stopAsync;
+            readonly CancellationToken cancellationToken;
+
+            public ClientReceiver(ILogger logger, IClientsService clientsService, ISignalRClient signalRClient,
+                    Func<Task> stopAsync, CancellationToken cancellationToken) {
+                this.logger = logger;
+                this.clientsService = clientsService;
+                this.signalRClient = signalRClient;
+                this.stopAsync = stopAsync;
+                this.cancellationToken = cancellationToken;
+            }
+
+            public async Task Errors(string message) {
+                logger.Error(message);
+                await stopAsync();
+            }
+
+            public async Task UdpRequest(UdpDataRequestModel request) {
+                var client = clientsService.ObtainUdpClient(request.Port, request.OriginPort, signalRClient);
+                await client.SendRequest(request.Data, cancellationToken);
+                if(!client.Listening) {
+                    client.Listen(request, signalRClient, cancellationToken);
+                }
+            }
+
+            public Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
+                logger.Debug($"HandleDisconnectUdp :{socketAddress}, {totalTransfered}");
+                var client = clientsService.ObtainUdpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient);
+                client.Disconnect(totalTransfered);
+                return Task.CompletedTask;
+            }
+
+            public async Task<SocketError> ConnectTcp(SocketAddressModel socketAddress) {
+                logger.Debug($"HandleConnectTcp :{socketAddress}");
+                var client = clientsService.AddTcpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient);
+                var result = await client.Connect(cancellationToken);
+                if(result != SocketError.Success) {
+                    await client.DisconnectAsync();
+                }
+                return result;
+            }
+
+            public async Task<int> TcpRequest(TcpDataRequestModel request) {
+                if(!clientsService.ObtainTcpClient(request.Port, request.OriginPort, out TcpClient? client)) {
+                    return -1;
+                }
+                return await client!.SendRequest(request.Data, cancellationToken);
+            }
+
+            public async Task<bool> DisconnectTcp(SocketAddressModel socketAddress) {
+                if(!clientsService.ObtainTcpClient(socketAddress.Port, socketAddress.OriginPort, out TcpClient? client)) {
+                    return true;
+                }
+                return await client!.DisconnectAsync();
+            }
+        }
         #endregion
 
         readonly ILogger logger;
         readonly IClientsService clientsService;
         HubConnection? connection = null;
+        IServerHub? hubProxy = null;
+        IDisposable? receiverSubscription = null;
 
         public SignalRClient(
                 ILogger logger,
@@ -85,48 +150,9 @@ namespace TutoProxy.Client.Communication {
                  })
                  .Build();
 
-            connection.On<UdpDataRequestModel>("UdpRequest", async (request) => {
-                var client = clientsService.ObtainUdpClient(request.Port, request.OriginPort, this);
-                await client.SendRequest(request.Data, cancellationToken);
-                if(!client.Listening) {
-                    client.Listen(request, this, cancellationToken);
-                }
-            });
-
-            connection.On<SocketAddressModel, Int64>("DisconnectUdp", (socketAddress, totalTransfered) => {
-                logger.Debug($"HandleDisconnectUdp :{socketAddress}, {totalTransfered}");
-                var client = clientsService.ObtainUdpClient(socketAddress.Port, socketAddress.OriginPort, this);
-                client.Disconnect(totalTransfered);
-            });
-
-            connection.On<SocketAddressModel, SocketError>("ConnectTcp", async (socketAddress) => {
-                logger.Debug($"HandleConnectTcp :{socketAddress}");
-                var client = clientsService.AddTcpClient(socketAddress.Port, socketAddress.OriginPort, this);
-                var result = await client.Connect(cancellationToken);
-                if(result != SocketError.Success) {
-                    await client!.DisconnectAsync();
-                }
-                return result;
-            });
-
-            connection.On<TcpDataRequestModel, int>("TcpRequest", async (request) => {
-                if(!clientsService.ObtainTcpClient(request.Port, request.OriginPort, out TcpClient? client)) {
-                    return -1;
-                }
-                return await client!.SendRequest(request.Data, cancellationToken);
-            });
-
-            connection.On<SocketAddressModel, bool>("DisconnectTcp", async (socketAddress) => {
-                if(!clientsService.ObtainTcpClient(socketAddress.Port, socketAddress.OriginPort, out TcpClient? client)) {
-                    return true;
-                }
-                return await client!.DisconnectAsync();
-            });
-
-            connection.On<string>("Errors", async (message) => {
-                logger.Error(message);
-                await StopAsync();
-            });
+            hubProxy = connection.CreateHubProxy<IServerHub>();
+            var receiver = new ClientReceiver(logger, clientsService, this, StopAsync, cancellationToken);
+            receiverSubscription = connection.Register<IClientReceiver>(receiver);
 
             connection.Reconnecting += e => {
                 logger.Warning($"Connection lost. Reconnecting");
@@ -144,6 +170,9 @@ namespace TutoProxy.Client.Communication {
         }
 
         public async Task StopAsync() {
+            receiverSubscription?.Dispose();
+            receiverSubscription = null;
+            hubProxy = null;
             if(connection != null) {
                 await connection.DisposeAsync();
                 logger.Information("Connection stopped");
@@ -152,27 +181,27 @@ namespace TutoProxy.Client.Communication {
         }
 
         public async Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken) {
-            if(connection?.State == HubConnectionState.Connected) {
-                await connection.SendAsync("UdpResponse", response, cancellationToken);
+            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
+                await hubProxy.UdpResponse(response);
             }
         }
 
         public async Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken) {
-            if(connection?.State == HubConnectionState.Connected) {
-                await connection.SendAsync("DisconnectUdp", socketAddress, totalTransfered, cancellationToken);
+            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
+                await hubProxy.DisconnectUdp(socketAddress, totalTransfered);
             }
         }
 
         public Task<int> SendTcpResponse(TcpDataResponseModel response, CancellationToken cancellationToken) {
-            if(connection?.State == HubConnectionState.Connected) {
-                return connection.InvokeAsync<int>("TcpResponse", response, cancellationToken);
+            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
+                return hubProxy.TcpResponse(response);
             }
             return Task.FromResult(-1);
         }
 
         public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
-            if(connection?.State == HubConnectionState.Connected) {
-                return connection.InvokeAsync<bool>("DisconnectTcp", socketAddress, cancellationToken);
+            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
+                return hubProxy.DisconnectTcp(socketAddress);
             }
             return Task.FromResult(false);
         }

--- a/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
+++ b/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
@@ -13,6 +13,10 @@
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.4" />
     <PackageReference Include="Terminal.Gui" Version="1.18.0" />
+    <PackageReference Include="TypedSignalR.Client" Version="3.6.0">
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+      <PrivateAssets>all</PrivateAssets>
+    </PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Communication/HubClientTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Communication/HubClientTests.cs
@@ -4,8 +4,8 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using TutoProxy.Server.Communication;
+using TuToProxy.Core;
 using TuToProxy.Core.Exceptions;
 using TuToProxy.Core.Models;
 
@@ -15,14 +15,12 @@ namespace TutoProxy.Server.Tests.Services {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         Mock<IServiceProvider> serviceProviderMock;
-        Mock<IClientProxy> clientProxyMock;
+        Mock<IClientHub> clientProxyMock;
         Mock<IServerFactory> serverFactoryMock;
         Mock<ITcpServer> tcpServerMock;
         Mock<IUdpServer> udpServerMock;
 
         IPEndPoint localEndPoint = new IPEndPoint(IPAddress.Loopback, 0);
-
-        string? clientsRequest;
 
         [SetUp]
         public void Setup() {
@@ -31,13 +29,6 @@ namespace TutoProxy.Server.Tests.Services {
             serverFactoryMock = new();
             tcpServerMock = new();
             udpServerMock = new();
-
-            clientsRequest = null;
-            clientProxyMock
-                .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
-                .Callback<string, object?[], CancellationToken>((method, args, cancellationToken) => {
-                    clientsRequest = args[0] as string;
-                });
 
             serviceProviderMock
                 .Setup(x => x.GetService(It.IsAny<Type>()))

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Communication/HubClientTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Communication/HubClientTests.cs
@@ -15,7 +15,6 @@ namespace TutoProxy.Server.Tests.Services {
 #pragma warning disable CS8618 // Non-nullable field must contain a non-null value when exiting constructor. Consider declaring as nullable.
 
         Mock<IServiceProvider> serviceProviderMock;
-        Mock<IClientHub> clientProxyMock;
         Mock<IServerFactory> serverFactoryMock;
         Mock<ITcpServer> tcpServerMock;
         Mock<IUdpServer> udpServerMock;
@@ -25,7 +24,6 @@ namespace TutoProxy.Server.Tests.Services {
         [SetUp]
         public void Setup() {
             serviceProviderMock = new();
-            clientProxyMock = new();
             serverFactoryMock = new();
             tcpServerMock = new();
             udpServerMock = new();
@@ -61,7 +59,7 @@ namespace TutoProxy.Server.Tests.Services {
                 .Setup(x => x.Listen())
                 .Returns(Task.CompletedTask);
 
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             await testable.Listen();
@@ -71,7 +69,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task SendUdpResponse_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             await testable.SendUdpResponse(new UdpDataResponseModel() { Port = 1000, OriginPort = 1000, Data = new byte[] { 0, 1 } });
@@ -80,7 +78,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task SendUdpResponse_Throws_SocketPortNotBoundException_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             Assert.ThrowsAsync<SocketPortNotBoundException>(async () => await testable.SendUdpResponse(
@@ -90,7 +88,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task DisconnectUdp_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             await testable.DisconnectUdpAsync(new SocketAddressModel() { Port = 1000, OriginPort = 10000 }, 42);
@@ -99,7 +97,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task DisconnectUdp_Throws_SocketPortNotBoundException_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(), Enumerable.Range(1000, 4), serviceProviderMock.Object);
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(), Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             Assert.ThrowsAsync<SocketPortNotBoundException>(async () => await testable.DisconnectUdpAsync(new SocketAddressModel() { Port = 11, OriginPort = 10000 }, 42),
                     "Udp socket port(11) not bound");
@@ -107,7 +105,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task SendTcpResponse_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             await testable.SendTcpResponse(new TcpDataResponseModel() { Port = 10, OriginPort = 1000, Data = new byte[] { 0, 1 } });
@@ -116,7 +114,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task SendTcpResponse_Throws_SocketPortNotBoundException_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             Assert.ThrowsAsync<SocketPortNotBoundException>(async () => await testable.SendTcpResponse(
@@ -126,7 +124,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task DisconnectTcp_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             await testable.DisconnectTcp(new SocketAddressModel() { Port = 10, OriginPort = 10000 });
@@ -135,7 +133,7 @@ namespace TutoProxy.Server.Tests.Services {
 
         [Test]
         public async Task DisconnectTcp_Throws_SocketPortNotBoundException_Test() {
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object, Enumerable.Range(1, 10).ToList(),
+            await using var testable = new HubClient(localEndPoint,  Enumerable.Range(1, 10).ToList(),
                 Enumerable.Range(1000, 4), serviceProviderMock.Object);
 
             Assert.Throws<SocketPortNotBoundException>(() => testable.DisconnectTcp(new SocketAddressModel() { Port = 110, OriginPort = 10000 }),
@@ -152,7 +150,7 @@ namespace TutoProxy.Server.Tests.Services {
                 .Setup(x => x.Listen())
                 .Returns(Task.CompletedTask);
 
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object,
+            await using var testable = new HubClient(localEndPoint, 
                 new List<int> { 8080 }, new List<int> { 9000 }, serviceProviderMock.Object);
 
             var ex = Assert.ThrowsAsync<InvalidOperationException>(testable.Listen);
@@ -169,7 +167,7 @@ namespace TutoProxy.Server.Tests.Services {
                 .Setup(x => x.Listen())
                 .Returns(Task.FromException(expectedException));
 
-            await using var testable = new HubClient(localEndPoint, clientProxyMock.Object,
+            await using var testable = new HubClient(localEndPoint, 
                 new List<int> { 8080 }, new List<int> { 9000 }, serviceProviderMock.Object);
 
             var ex = Assert.ThrowsAsync<InvalidOperationException>(testable.Listen);

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Services/DataTransferServiceTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Services/DataTransferServiceTests.cs
@@ -5,6 +5,7 @@ using Microsoft.AspNetCore.SignalR;
 using Serilog;
 using TutoProxy.Server.Hubs;
 using TutoProxy.Server.Services;
+using TuToProxy.Core;
 using TuToProxy.Core.Models;
 
 namespace TutoProxy.Server.Tests.Services {
@@ -13,50 +14,38 @@ namespace TutoProxy.Server.Tests.Services {
     public class DataTransferServiceTests {
         DataTransferService testable;
 
-        Mock<ISingleClientProxy> clientProxyMock;
+        Mock<IClientHub> typedClientMock;
         Mock<IHubClientsService> clientsServiceMock;
-
-        UdpDataRequestModel? sendedTransferUdpRequest;
 
         [SetUp]
         public void Setup() {
             var loggerMock = new Mock<ILogger>();
-            var hubContextMock = new Mock<IHubContext<SignalRHub>>();
-            var hubClientsMock = new Mock<IHubClients>();
-            clientProxyMock = new();
+            var typedHubContextMock = new Mock<IHubContext<SignalRHub, IClientHub>>();
+            var rawHubContextMock = new Mock<IHubContext<SignalRHub>>();
+            var typedHubClientsMock = new Mock<IHubClients<IClientHub>>();
+            typedClientMock = new();
             clientsServiceMock = new();
 
-            hubClientsMock
-                .SetupGet(x => x.All)
-                .Returns(() => clientProxyMock.Object);
-
-            hubClientsMock
+            typedHubClientsMock
                 .Setup(x => x.Client(It.IsAny<string>()))
-                .Returns(() => clientProxyMock.Object);
+                .Returns(() => typedClientMock.Object);
 
-            hubContextMock
+            typedHubContextMock
                 .SetupGet(x => x.Clients)
-                .Returns(() => hubClientsMock.Object);
-
-            sendedTransferUdpRequest = null;
-            clientProxyMock
-                .Setup(x => x.SendCoreAsync(It.IsAny<string>(), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()))
-                .Callback<string, object?[], CancellationToken>((method, args, cancellationToken) => {
-                    sendedTransferUdpRequest = args[0] as UdpDataRequestModel;
-                });
+                .Returns(() => typedHubClientsMock.Object);
 
             clientsServiceMock
                 .Setup(x => x.GetConnectionIdForUdp(It.IsAny<int>()))
                 .Returns<int>((port) => $"udp-{port}");
 
-            testable = new DataTransferService(loggerMock.Object, hubContextMock.Object, clientsServiceMock.Object);
+            testable = new DataTransferService(loggerMock.Object, typedHubContextMock.Object, rawHubContextMock.Object, clientsServiceMock.Object);
         }
 
         [Test]
         public async Task SendUdpRequest_Test() {
             var requestModel = new UdpDataRequestModel() { Port = 700, OriginPort = 800, Data = Array.Empty<byte>() };
             await testable.SendUdpRequest(requestModel, new CancellationTokenSource().Token);
-            clientProxyMock.Verify(x => x.SendCoreAsync(It.Is<string>(m => m == "UdpRequest"), It.IsAny<object?[]>(), It.IsAny<CancellationToken>()), Times.Once);
+            typedClientMock.Verify(x => x.UdpRequest(It.Is<UdpDataRequestModel>(r => r.Port == 700)), Times.Once);
         }
     }
 }

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
@@ -45,7 +45,6 @@ namespace TutoProxy.Server.Tests.Services {
         Mock<ILogger> loggerMock;
         Mock<IHostApplicationLifetime> applicationLifetimeMock;
         Mock<IServiceProvider> serviceProviderMock;
-        Mock<IClientHub> clientProxyMock;
         Mock<IDataTransferService> dataTransferServiceMock;
         Mock<IProcessMonitor> processMonitorMock;
         Mock<IServerFactory> serverFactoryMock;
@@ -58,7 +57,6 @@ namespace TutoProxy.Server.Tests.Services {
             loggerMock = new();
             applicationLifetimeMock = new();
             serviceProviderMock = new();
-            clientProxyMock = new();
             dataTransferServiceMock = new();
             processMonitorMock = new();
             serverFactoryMock = new();
@@ -95,24 +93,24 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
 
-            await testable.Connect("connectionId0", clientProxyMock.Object, "tcpquery=80,81,443");
-            await testable.Connect("connectionId1", clientProxyMock.Object, "tcpquery=180,181,1443");
+            await testable.Connect("connectionId0", "tcpquery=80,81,443");
+            await testable.Connect("connectionId1", "tcpquery=180,181,1443");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0", "connectionId1" }));
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", clientProxyMock.Object, "tcpquery=80"), "tcp ports already in use");
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", clientProxyMock.Object, "tcpquery=180,181,1443"), "tcp ports already in use");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", "tcpquery=80"), "tcp ports already in use");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", "tcpquery=180,181,1443"), "tcp ports already in use");
         }
 
         [Test]
         public async Task Clients_WithAlready_Used_UdpPort_Are_Rejected_Test() {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
-            await testable.Connect("connectionId0", clientProxyMock.Object, "udpquery=1080,1081,10443");
-            await testable.Connect("connectionId1", clientProxyMock.Object, "udpquery=10180,10181,11443");
+            await testable.Connect("connectionId0", "udpquery=1080,1081,10443");
+            await testable.Connect("connectionId1", "udpquery=10180,10181,11443");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0", "connectionId1" }));
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", clientProxyMock.Object, "udpquery=1080"), "udp ports already in use");
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", clientProxyMock.Object, "udpquery=10180,10181,11443"), "udp ports already in use");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", "udpquery=1080"), "udp ports already in use");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", "udpquery=10180,10181,11443"), "udp ports already in use");
         }
 
         [Test]
@@ -120,12 +118,12 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1000, 4), Enumerable.Range(1, 65535), null);
 
-            await testable.Connect("connectionId0", clientProxyMock.Object, "tcpquery=1000,1001");
-            await testable.Connect("connectionId1", clientProxyMock.Object, "tcpquery=1002,1003");
+            await testable.Connect("connectionId0", "tcpquery=1000,1001");
+            await testable.Connect("connectionId1", "tcpquery=1002,1003");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0", "connectionId1" }));
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", clientProxyMock.Object, "tcpquery=1004"), "banned tcp ports");
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", clientProxyMock.Object, "tcpquery=180,181,1443"), "banned tcp ports");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", "tcpquery=1004"), "banned tcp ports");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", "tcpquery=180,181,1443"), "banned tcp ports");
         }
 
         [Test]
@@ -133,12 +131,12 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1000, 4), null);
 
-            await testable.Connect("connectionId0", clientProxyMock.Object, "udpquery=1000,1001");
-            await testable.Connect("connectionId1", clientProxyMock.Object, "udpquery=1002,1003");
+            await testable.Connect("connectionId0", "udpquery=1000,1001");
+            await testable.Connect("connectionId1", "udpquery=1002,1003");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0", "connectionId1" }));
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", clientProxyMock.Object, "udpquery=1004"), "banned udp ports");
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", clientProxyMock.Object, "udpquery=180,181,1443"), "banned udp ports");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", "udpquery=1004"), "banned udp ports");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId3", "udpquery=180,181,1443"), "banned udp ports");
         }
 
         [Test]
@@ -146,10 +144,10 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId1", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId1", new HubClient(localEndPoint, 
                             Enumerable.Range(2000, 1).ToList(), Enumerable.Range(2000, 1), serviceProviderMock.Object));
 
             Assert.That(testable.GetClient("connectionId0")?.TcpPorts, Has.Member(1000));
@@ -163,7 +161,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
 
             Assert.Throws<HubClientNotFoundException>(() => testable.GetClient("connectionId19"));
@@ -174,7 +172,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
             testable.PublicTcpPortToConnectionId[1000] = "connectionId0";
 
@@ -186,7 +184,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
             testable.PublicTcpPortToConnectionId[1000] = "connectionId0";
 
@@ -198,7 +196,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
             testable.PublicUdpPortToConnectionId[1000] = "connectionId0";
 
@@ -210,7 +208,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, clientProxyMock.Object,
+            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
                             Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
             testable.PublicUdpPortToConnectionId[1000] = "connectionId0";
 
@@ -222,10 +220,10 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), new string[] { "client1", "client2" });
 
-            await testable.Connect("connectionId0", clientProxyMock.Object, "tcpquery=80&clientid=client1");
+            await testable.Connect("connectionId0", "tcpquery=80&clientid=client1");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0" }));
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", clientProxyMock.Object, "tcpquery=80&clientid=clientOther"), "client denied");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId2", "tcpquery=80&clientid=clientOther"), "client denied");
         }
 
         [Test]
@@ -233,9 +231,9 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
 
-            await testable.Connect("connectionId0", clientProxyMock.Object, "tcpquery=80&clientid=client1");
-            await testable.Connect("connectionId1", clientProxyMock.Object, "tcpquery=81&clientid=client2");
-            await testable.Connect("connectionId99", clientProxyMock.Object, "tcpquery=899&clientid=client99");
+            await testable.Connect("connectionId0", "tcpquery=80&clientid=client1");
+            await testable.Connect("connectionId1", "tcpquery=81&clientid=client2");
+            await testable.Connect("connectionId99", "tcpquery=899&clientid=client99");
             Assert.That(testable.PublicMorozovConnectedClients.Keys, Is.EquivalentTo(new[] { "connectionId0", "connectionId1", "connectionId99" }));
         }
 
@@ -244,7 +242,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), new string[] { "client1", "client2" });
 
-            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId0", clientProxyMock.Object, "tcpquery=80"), "clientId param requried");
+            Assert.ThrowsAsync<ClientConnectionException>(() => testable.Connect("connectionId0", "tcpquery=80"), "clientId param requried");
         }
 
         [Test]
@@ -273,7 +271,7 @@ namespace TutoProxy.Server.Tests.Services {
                 threads[i] = new Thread(() => {
                     barrier.SignalAndWait(); // Синхронизируем старт всех потоков
                     try {
-                        testable.Connect(connectionId, clientProxyMock.Object, $"tcpquery={targetPort}").GetAwaiter().GetResult();
+                        testable.Connect(connectionId, $"tcpquery={targetPort}").GetAwaiter().GetResult();
                         Interlocked.Increment(ref successCount);
                     } catch(ClientConnectionException) {
                         Interlocked.Increment(ref exceptionCount);

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
@@ -5,11 +5,11 @@ using System.Linq;
 using System.Net;
 using System.Threading;
 using System.Threading.Tasks;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.Hosting;
 using Serilog;
 using TutoProxy.Server.Communication;
 using TutoProxy.Server.Services;
+using TuToProxy.Core;
 using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Tests.Services {
@@ -45,7 +45,7 @@ namespace TutoProxy.Server.Tests.Services {
         Mock<ILogger> loggerMock;
         Mock<IHostApplicationLifetime> applicationLifetimeMock;
         Mock<IServiceProvider> serviceProviderMock;
-        Mock<IClientProxy> clientProxyMock;
+        Mock<IClientHub> clientProxyMock;
         Mock<IDataTransferService> dataTransferServiceMock;
         Mock<IProcessMonitor> processMonitorMock;
         Mock<IServerFactory> serverFactoryMock;

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
@@ -1,4 +1,5 @@
-﻿using System.Net;
+﻿using System.Collections.Frozen;
+using System.Net;
 using System.Threading;
 using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
@@ -11,8 +12,8 @@ namespace TutoProxy.Server.Communication {
         public IEnumerable<int>? TcpPorts { get; private set; }
         public IEnumerable<int>? UdpPorts { get; private set; }
 
-        readonly Dictionary<int, ITcpServer> tcpServers = new();
-        readonly Dictionary<int, IUdpServer> udpServers = new();
+        readonly FrozenDictionary<int, ITcpServer> tcpServers;
+        readonly FrozenDictionary<int, IUdpServer> udpServers;
         readonly CancellationTokenSource cts;
 
         public HubClient(IPEndPoint localEndPoint, IClientProxy clientProxy, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
@@ -26,16 +27,16 @@ namespace TutoProxy.Server.Communication {
             var serverFactory = serviceProvider.GetRequiredService<IServerFactory>();
             if(tcpPorts != null) {
                 tcpServers = tcpPorts
-                    .ToDictionary(k => k, v => serverFactory.CreateTcp(v, localEndPoint));
+                    .ToFrozenDictionary(k => k, v => serverFactory.CreateTcp(v, localEndPoint));
             } else {
-                tcpServers = new();
+                tcpServers = FrozenDictionary<int, ITcpServer>.Empty;
             }
 
             if(udpPorts != null) {
                 udpServers = udpPorts
-                    .ToDictionary(k => k, v => serverFactory.CreateUdp(v, localEndPoint, UdpSocketParams.ReceiveTimeout));
+                    .ToFrozenDictionary(k => k, v => serverFactory.CreateUdp(v, localEndPoint, UdpSocketParams.ReceiveTimeout));
             } else {
-                udpServers = new();
+                udpServers = FrozenDictionary<int, IUdpServer>.Empty;
             }
         }
 
@@ -52,13 +53,8 @@ namespace TutoProxy.Server.Communication {
         }
 
         public Task Listen() {
-            var tasks = new List<Task>();
-            if(tcpServers != null) {
-                tasks.AddRange(tcpServers.Values.Select(x => x.Listen()));
-            }
-            if(udpServers != null) {
-                tasks.AddRange(udpServers.Values.Select(x => x.Listen()));
-            }
+            var tasks = tcpServers.Values.Select(x => x.Listen())
+                .Concat(udpServers.Values.Select(x => x.Listen()));
             return Task.WhenAll(tasks);
         }
 

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
@@ -1,14 +1,13 @@
 ﻿using System.Collections.Frozen;
 using System.Net;
 using System.Threading;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.Extensions.DependencyInjection;
 using TuToProxy.Core;
 using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Communication {
     public class HubClient : IAsyncDisposable {
-        public IClientProxy ClientProxy { get; private set; }
+        public IClientHub ClientProxy { get; private set; }
         public IEnumerable<int>? TcpPorts { get; private set; }
         public IEnumerable<int>? UdpPorts { get; private set; }
 
@@ -16,7 +15,7 @@ namespace TutoProxy.Server.Communication {
         readonly FrozenDictionary<int, IUdpServer> udpServers;
         readonly CancellationTokenSource cts;
 
-        public HubClient(IPEndPoint localEndPoint, IClientProxy clientProxy, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
+        public HubClient(IPEndPoint localEndPoint, IClientHub clientProxy, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
                     IServiceProvider serviceProvider) {
             ClientProxy = clientProxy;
             TcpPorts = tcpPorts;

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
@@ -7,7 +7,6 @@ using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Communication {
     public class HubClient : IAsyncDisposable {
-        public IClientHub ClientProxy { get; private set; }
         public IEnumerable<int>? TcpPorts { get; private set; }
         public IEnumerable<int>? UdpPorts { get; private set; }
 
@@ -15,9 +14,8 @@ namespace TutoProxy.Server.Communication {
         readonly FrozenDictionary<int, IUdpServer> udpServers;
         readonly CancellationTokenSource cts;
 
-        public HubClient(IPEndPoint localEndPoint, IClientHub clientProxy, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
+        public HubClient(IPEndPoint localEndPoint, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
                     IServiceProvider serviceProvider) {
-            ClientProxy = clientProxy;
             TcpPorts = tcpPorts;
             UdpPorts = udpPorts;
 

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
@@ -1,10 +1,10 @@
-﻿using System.Threading.Tasks.Dataflow;
-using Microsoft.AspNetCore.SignalR;
+﻿using Microsoft.AspNetCore.SignalR;
 using TutoProxy.Server.Services;
+using TuToProxy.Core;
 using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Hubs {
-    public class SignalRHub : Hub {
+    public class SignalRHub : Hub<IClientHub> {
         readonly ILogger logger;
         readonly IDataTransferService dataTransferService;
         readonly IHubClientsService clientsService;
@@ -26,7 +26,7 @@ namespace TutoProxy.Server.Hubs {
             try {
                 await dataTransferService.HandleUdpResponse(Context.ConnectionId, model);
             } catch(TuToException ex) {
-                await Clients.Caller.SendAsync("Errors", ex.Message);
+                await Clients.Caller.Errors(ex.Message);
             }
         }
 
@@ -35,7 +35,7 @@ namespace TutoProxy.Server.Hubs {
             try {
                 await dataTransferService.HandleDisconnectUdpAsync(Context.ConnectionId, socketAddress, totalTransfered);
             } catch(TuToException ex) {
-                await Clients.Caller.SendAsync("Errors", ex.Message);
+                await Clients.Caller.Errors(ex.Message);
             }
         }
 
@@ -44,7 +44,7 @@ namespace TutoProxy.Server.Hubs {
             try {
                 return await dataTransferService.HandleTcpResponse(Context.ConnectionId, model);
             } catch(TuToException ex) {
-                await Clients.Caller.SendAsync("Errors", ex.Message);
+                await Clients.Caller.Errors(ex.Message);
                 return -1;
             }
         }
@@ -54,7 +54,7 @@ namespace TutoProxy.Server.Hubs {
             try {
                 return await dataTransferService.HandleDisconnectTcp(Context.ConnectionId, socketAddress);
             } catch(TuToException ex) {
-                await Clients.Caller.SendAsync("Errors", ex.Message);
+                await Clients.Caller.Errors(ex.Message);
                 return false;
             }
         }
@@ -65,7 +65,7 @@ namespace TutoProxy.Server.Hubs {
                 await clientsService.Connect(Context.ConnectionId, Clients.Caller, queryString);
             } catch(TuToException ex) {
                 logger.Error(ex.Message);
-                await Clients.Caller.SendAsync("Errors", ex.Message);
+                await Clients.Caller.Errors(ex.Message);
             }
             await base.OnConnectedAsync();
         }

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
@@ -62,7 +62,7 @@ namespace TutoProxy.Server.Hubs {
         public override async Task OnConnectedAsync() {
             try {
                 var queryString = Context.GetHttpContext()?.Request.QueryString.Value;
-                await clientsService.Connect(Context.ConnectionId, Clients.Caller, queryString);
+                await clientsService.Connect(Context.ConnectionId, queryString);
             } catch(TuToException ex) {
                 logger.Error(ex.Message);
                 await Clients.Caller.Errors(ex.Message);

--- a/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
@@ -1,6 +1,7 @@
 ﻿using System.Net.Sockets;
 using Microsoft.AspNetCore.SignalR;
 using TutoProxy.Server.Hubs;
+using TuToProxy.Core;
 
 namespace TutoProxy.Server.Services {
     public interface IDataTransferService {
@@ -18,32 +19,36 @@ namespace TutoProxy.Server.Services {
 
     public class DataTransferService : IDataTransferService {
         readonly ILogger logger;
-        readonly IHubContext<SignalRHub> signalHub;
+        readonly IHubContext<SignalRHub, IClientHub> typedHub;
+        readonly IHubContext<SignalRHub> rawHub;
         readonly IHubClientsService clientsService;
 
         public DataTransferService(
                 ILogger logger,
-                IHubContext<SignalRHub> hubContext,
+                IHubContext<SignalRHub, IClientHub> typedHubContext,
+                IHubContext<SignalRHub> rawHubContext,
                 IHubClientsService clientsService
             ) {
             Guard.NotNull(logger, nameof(logger));
-            Guard.NotNull(hubContext, nameof(hubContext));
+            Guard.NotNull(typedHubContext, nameof(typedHubContext));
+            Guard.NotNull(rawHubContext, nameof(rawHubContext));
             Guard.NotNull(clientsService, nameof(clientsService));
             this.logger = logger;
-            this.signalHub = hubContext;
+            this.typedHub = typedHubContext;
+            this.rawHub = rawHubContext;
             this.clientsService = clientsService;
         }
 
         public async Task SendUdpRequest(UdpDataRequestModel request, CancellationToken cancellationToken) {
             logger.Debug($"UdpRequest :{request}");
             var connectionId = clientsService.GetConnectionIdForUdp(request.Port);
-            await signalHub.Clients.Client(connectionId).SendAsync("UdpRequest", request, cancellationToken);
+            await typedHub.Clients.Client(connectionId).UdpRequest(request);
         }
 
         public async Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
             logger.Debug($"DisconnectUdp :{socketAddress}, {totalTransfered}");
             var connectionId = clientsService.GetConnectionIdForUdp(socketAddress.Port);
-            await signalHub.Clients.Client(connectionId).SendAsync("DisconnectUdp", socketAddress, totalTransfered);
+            await typedHub.Clients.Client(connectionId).DisconnectUdp(socketAddress, totalTransfered);
         }
 
         public async Task HandleUdpResponse(string connectionId, UdpDataResponseModel response) {
@@ -59,13 +64,13 @@ namespace TutoProxy.Server.Services {
         public Task<SocketError> ConnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
             logger.Debug($"ConnectTcp :{socketAddress}");
             var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
-            return signalHub.Clients.Client(connectionId).InvokeAsync<SocketError>("ConnectTcp", socketAddress, cancellationToken);
+            return rawHub.Clients.Client(connectionId).InvokeAsync<SocketError>(ClientMethods.ConnectTcp, socketAddress, cancellationToken);
         }
 
         public async Task<int> SendTcpRequest(TcpDataRequestModel request, CancellationToken cancellationToken) {
             logger.Debug($"TcpRequest :{request}");
             var connectionId = clientsService.GetConnectionIdForTcp(request.Port);
-            return await signalHub.Clients.Client(connectionId).InvokeAsync<int>("TcpRequest", request, cancellationToken);
+            return await rawHub.Clients.Client(connectionId).InvokeAsync<int>(ClientMethods.TcpRequest, request, cancellationToken);
         }
 
         public ValueTask<int> HandleTcpResponse(string connectionId, TcpDataResponseModel response) {
@@ -76,7 +81,7 @@ namespace TutoProxy.Server.Services {
         public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
             logger.Debug($"DisconnectTcp :{socketAddress}");
             var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
-            return signalHub.Clients.Client(connectionId).InvokeAsync<bool>("DisconnectTcp", socketAddress, cancellationToken);
+            return rawHub.Clients.Client(connectionId).InvokeAsync<bool>(ClientMethods.DisconnectTcp, socketAddress, cancellationToken);
         }
 
         public ValueTask<bool> HandleDisconnectTcp(string connectionId, SocketAddressModel socketAddress) {

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -93,16 +93,12 @@ namespace TutoProxy.Server.Services {
                 throw new ClientConnectionException(clientId, connectionId, "tcp or udp options error");
             }
 
-            var bannedTcpPorts = GetBannedPorts(alowedTcpPorts, tcpPorts);
-            if(bannedTcpPorts.Any()) {
-                var message = $"banned tcp ports [{string.Join(",", bannedTcpPorts)}]";
-                throw new ClientConnectionException(clientId, connectionId, message);
+            if(HasBannedPorts(alowedTcpPorts, tcpPorts)) {
+                throw new ClientConnectionException(clientId, connectionId, "one of tcp ports is not allowed");
             }
 
-            var bannedUdpPorts = GetBannedPorts(alowedUdpPorts, udpPorts);
-            if(bannedUdpPorts.Any()) {
-                var message = $"banned udp ports [{string.Join(",", bannedUdpPorts)}]";
-                throw new ClientConnectionException(clientId, connectionId, message);
+            if(HasBannedPorts(alowedUdpPorts, udpPorts)) {
+                throw new ClientConnectionException(clientId, connectionId, "one of udp ports is not allowed");
             }
 
             if(tcpPorts != null) {
@@ -161,11 +157,16 @@ namespace TutoProxy.Server.Services {
             }
         }
 
-        IEnumerable<int> GetBannedPorts(HashSet<int>? allowedPorts, IEnumerable<int>? ports) {
-            if(allowedPorts != null && ports != null) {
-                return ports.Where(x => !allowedPorts.Contains(x));
+        bool HasBannedPorts(HashSet<int>? allowedPorts, List<int>? ports) {
+            if(allowedPorts == null || ports == null) {
+                return false;
             }
-            return Enumerable.Empty<int>();
+            foreach(var port in ports) {
+                if(!allowedPorts.Contains(port)) {
+                    return true;
+                }
+            }
+            return false;
         }
 
         public async ValueTask DisposeAsync() {

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -1,6 +1,5 @@
 ﻿using System.Collections.Concurrent;
 using System.Net;
-using Microsoft.AspNetCore.SignalR;
 using Microsoft.AspNetCore.WebUtilities;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Primitives;
@@ -11,7 +10,7 @@ using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Services {
     public interface IHubClientsService : IAsyncDisposable {
-        Task Connect(string connectionId, IClientProxy clientProxy, string? queryString);
+        Task Connect(string connectionId, IClientHub clientProxy, string? queryString);
         Task DisconnectAsync(string connectionId);
         HubClient GetClient(string connectionId);
         string GetConnectionIdForTcp(int port);
@@ -56,7 +55,7 @@ namespace TutoProxy.Server.Services {
             this.alowedClients = alowedClients?.ToHashSet();
         }
 
-        public async Task Connect(string connectionId, IClientProxy clientProxy, string? queryString) {
+        public async Task Connect(string connectionId, IClientHub clientProxy, string? queryString) {
             if(queryString == null) {
                 throw new ClientConnectionException(connectionId, "QueryString empty");
             }

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -10,7 +10,7 @@ using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Services {
     public interface IHubClientsService : IAsyncDisposable {
-        Task Connect(string connectionId, IClientHub clientProxy, string? queryString);
+        Task Connect(string connectionId, string? queryString);
         Task DisconnectAsync(string connectionId);
         HubClient GetClient(string connectionId);
         string GetConnectionIdForTcp(int port);
@@ -55,7 +55,7 @@ namespace TutoProxy.Server.Services {
             this.alowedClients = alowedClients?.ToHashSet();
         }
 
-        public async Task Connect(string connectionId, IClientHub clientProxy, string? queryString) {
+        public async Task Connect(string connectionId, string? queryString) {
             if(queryString == null) {
                 throw new ClientConnectionException(connectionId, "QueryString empty");
             }
@@ -115,7 +115,7 @@ namespace TutoProxy.Server.Services {
                 }
             }
 
-            var hubClient = new HubClient(localEndPoint, clientProxy, tcpPorts, udpPorts, serviceProvider);
+            var hubClient = new HubClient(localEndPoint, tcpPorts, udpPorts, serviceProvider);
             if(!connectedClients.TryAdd(connectionId, hubClient)) {
                 await hubClient.DisposeAsync();
 

--- a/Projects/TutoProxy/scripts/perf-test.sh
+++ b/Projects/TutoProxy/scripts/perf-test.sh
@@ -142,7 +142,8 @@ start_tutoproxy_server() {
 }
 
 start_tutoproxy_client() {
-    log_info "Starting TutoProxy.Client (connecting to server, forwarding to Docker iperf3 at $IPERF_SERVER_IP)..."
+    local protocol="${1:-Auto}"
+    log_info "Starting TutoProxy.Client (protocol: $protocol, forwarding to Docker iperf3 at $IPERF_SERVER_IP)..."
 
     # Client connects to our Server and forwards to iperf3 in Docker
     # Using the Docker container's IP address
@@ -152,6 +153,7 @@ start_tutoproxy_client() {
         "$IPERF_SERVER_IP" \
         --tcp="$TUNNEL_PORT" \
         --id="PerfTestClient" \
+        --protocol="$protocol" \
         --daemon &
 
     CLIENT_PID=$!
@@ -167,6 +169,20 @@ start_tutoproxy_client() {
     log_info "TutoProxy.Client started (PID: $CLIENT_PID)"
 }
 
+stop_tutoproxy() {
+    if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
+        kill "$SERVER_PID" 2>/dev/null || true
+        wait "$SERVER_PID" 2>/dev/null || true
+        SERVER_PID=""
+    fi
+
+    if [ -n "$CLIENT_PID" ] && kill -0 "$CLIENT_PID" 2>/dev/null; then
+        kill "$CLIENT_PID" 2>/dev/null || true
+        wait "$CLIENT_PID" 2>/dev/null || true
+        CLIENT_PID=""
+    fi
+}
+
 run_iperf_test() {
     local duration=${1:-10}
     local parallel=${2:-1}
@@ -180,25 +196,32 @@ run_iperf_test() {
     echo ""
 }
 
-run_baseline_test() {
-    local duration=${1:-10}
-
-    log_info "Running baseline test (direct to Docker iperf3 at $IPERF_SERVER_IP)..."
-    echo ""
-
-    # Direct connection to iperf3 in Docker (no tunnel)
-    iperf3 -c "$IPERF_SERVER_IP" -p 5201 -t "$duration"
+run_protocol_test() {
+    local protocol="$1"
+    local duration="$2"
+    local parallel="$3"
 
     echo ""
+    echo "========================================="
+    echo "  TUNNEL TEST ($protocol protocol)"
+    echo "========================================="
+
+    start_tutoproxy_server
+    start_tutoproxy_client "$protocol"
+
+    run_iperf_test "$duration" "$parallel"
+
+    stop_tutoproxy
 }
 
 print_usage() {
     echo "Usage: $0 [command] [options]"
     echo ""
     echo "Commands:"
-    echo "  full       Run full test (baseline + tunnel)"
-    echo "  tunnel     Run tunnel test only"
-    echo "  baseline   Run baseline test only (direct to iperf3)"
+    echo "  full       Run full test (Auto + Http + WebSocket)"
+    echo "  auto       Run tunnel test with Auto protocol"
+    echo "  http       Run tunnel test with Http protocol (LongPolling)"
+    echo "  websocket  Run tunnel test with WebSocket protocol (fastest)"
     echo ""
     echo "Options:"
     echo "  -d, --duration    Test duration in seconds (default: 10)"
@@ -206,8 +229,8 @@ print_usage() {
     echo ""
     echo "Examples:"
     echo "  $0 full"
-    echo "  $0 tunnel -d 30 -p 4"
-    echo "  $0 baseline -d 5"
+    echo "  $0 websocket -d 30 -p 4"
+    echo "  $0 auto -d 5"
 }
 
 main() {
@@ -244,43 +267,19 @@ main() {
     setup_docker
 
     case $command in
-        baseline)
-            echo ""
-            echo "========================================="
-            echo "  BASELINE TEST (Direct to iperf3)"
-            echo "========================================="
-            run_baseline_test "$duration"
+        auto)
+            run_protocol_test "Auto" "$duration" "$parallel"
             ;;
-        tunnel)
-            start_tutoproxy_server
-            start_tutoproxy_client
-
-            echo ""
-            echo "========================================="
-            echo "  TUNNEL TEST (Through TutoProxy)"
-            echo "========================================="
-            run_iperf_test "$duration" "$parallel"
+        http)
+            run_protocol_test "Http" "$duration" "$parallel"
+            ;;
+        websocket)
+            run_protocol_test "WebSocket" "$duration" "$parallel"
             ;;
         full)
-            echo ""
-            echo "========================================="
-            echo "  BASELINE TEST (Direct to iperf3)"
-            echo "========================================="
-            run_baseline_test "$duration"
-
-            # Stop iperf server to free port, restart for tunnel test
-            docker stop "$IPERF_SERVER_CONTAINER" 2>/dev/null || true
-            docker rm "$IPERF_SERVER_CONTAINER" 2>/dev/null || true
-            setup_docker
-
-            start_tutoproxy_server
-            start_tutoproxy_client
-
-            echo ""
-            echo "========================================="
-            echo "  TUNNEL TEST (Through TutoProxy)"
-            echo "========================================="
-            run_iperf_test "$duration" "$parallel"
+            run_protocol_test "Auto" "$duration" "$parallel"
+            run_protocol_test "Http" "$duration" "$parallel"
+            run_protocol_test "WebSocket" "$duration" "$parallel"
             ;;
         *)
             log_error "Unknown command: $command"

--- a/README.md
+++ b/README.md
@@ -9,37 +9,108 @@
 
 ### Applications
 
-The [TutoProxy.Server](https://github.com/viordash/TuToDataTunnel/tree/main/Projects/TutoProxy/TutoProxy.Server) application is an inbound server for tunneling clients and for tcp/udp end-clients. 
-cmd arguments:
-- \<host\>, server address, for example http://200.100.10.1:8088
-- **--tcp** \<tcp\>, list of tcp ports to listen to, for example --tcp=80,81,443,8000-8100. Optional, if --udp option is present.
-- **--udp** \<udp\>, list of udp ports to listen to, for example --udp=700-900,65500. Optional, if --tcp option is present.
-- **--clients** \<clients\> optional list of allowed clients, e.g. --clients=Client1,Client2 if this parameter is omitted, then there is no check for connecting client ID
-- **--daemon** optional, disable the terminal GUI
+#### TutoProxy.Server
 
-For example, start input traffic tunneling on 50 tcp/udp ports to 3 clients: 
+[TutoProxy.Server](https://github.com/viordash/TuToDataTunnel/tree/main/Projects/TutoProxy/TutoProxy.Server) - inbound server that accepts connections from tunneling clients (TutoProxy.Client) via SignalR and listens for incoming TCP/UDP traffic from external clients.
 
-    TutoProxy.Server http://200.100.10.1:8088 --tcp=3389,8071-8073,10000-10010,20000-20010 --udp=5000-5010,7000-7010 --clients=Client0Linux,ClientSecLinux,Client3Win
+**Command line arguments:**
 
-----------------------------------
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<host>` | Yes | Server binding address with port. Example: `http://0.0.0.0:8088` or `http://200.100.10.1:8088` |
+| `--tcp <ports>` | No* | TCP ports to listen on. Supports individual ports and ranges. Example: `--tcp=80,443,8000-8100` |
+| `--udp <ports>` | No* | UDP ports to listen on. Supports individual ports and ranges. Example: `--udp=5000-5010,65500` |
+| `--clients <list>` | No | Comma-separated list of allowed client IDs. If omitted, all clients are allowed |
+| `--daemon` | No | Run in daemon mode without terminal GUI, reduces CPU overhead |
 
-The [TutoProxy.Client](https://github.com/viordash/TuToDataTunnel/tree/main/Projects/TutoProxy/TutoProxy.Client) is an output tunneling client. 
-cmd arguments:
-- \<server\>, TutoProxy.Server server address, for example http://200.100.10.1:8088
-- \<sendto\>, the IP of the recipient of the data, for example 127.0.0.1
-- **--id** \<id\>, client ID, for example --id=Client1
-- **--tcp** \<tcp\>, list of tcp ports, for example --tcp=80,81,443,8000-8100. Optional, if --udp option is present.
-- **--udp** \<udp\>, list of udp ports, for example --udp=700-900,65500. Optional, if --tcp option is present.
-- **--daemon** optional, disable the terminal GUI
+*At least one of `--tcp` or `--udp` must be specified.
 
-For example, start output traffic tunneling on 5 tcp and 3 udp ports: 
+**Example - start server with 50 TCP/UDP ports for 3 specific clients:**
 
-    TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 --tcp=8071,10000,20004-20006 --udp=7000-7002 --id=Client0Linux
+```bash
+TutoProxy.Server http://200.100.10.1:8088 \
+    --tcp=3389,8071-8073,10000-10010,20000-20010 \
+    --udp=5000-5010,7000-7010 \
+    --clients=Client0Linux,ClientSecLinux,Client3Win
+```
 
+---
 
-*Keep in mind that ports of different TutoProxy.Clients should not overlap, i.e. each client serves a unique set of sockets/ports.*
+#### TutoProxy.Client
 
-----------------------------------
+[TutoProxy.Client](https://github.com/viordash/TuToDataTunnel/tree/main/Projects/TutoProxy/TutoProxy.Client) - tunneling client that connects to TutoProxy.Server via SignalR and forwards traffic to the target host.
+
+**Command line arguments:**
+
+| Argument | Required | Description |
+|----------|----------|-------------|
+| `<server>` | Yes | TutoProxy.Server address. Example: `http://200.100.10.1:8088` |
+| `<sendto>` | Yes | Target host IP where traffic will be forwarded. Example: `127.0.0.1` or `192.168.1.100` |
+| `--id <id>` | Yes | Unique client identifier. Must match allowed clients on server if restriction is enabled |
+| `--tcp <ports>` | No* | TCP ports to handle. Must be subset of server's TCP ports. Example: `--tcp=80,443` |
+| `--udp <ports>` | No* | UDP ports to handle. Must be subset of server's UDP ports. Example: `--udp=5000-5005` |
+| `--daemon` | No | Run in daemon mode without terminal GUI, reduces CPU overhead |
+
+*At least one of `--tcp` or `--udp` must be specified.
+
+**Example - start client forwarding 5 TCP and 3 UDP ports:**
+
+```bash
+TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 \
+    --tcp=8071,10000,20004-20006 \
+    --udp=7000-7002 \
+    --id=Client0Linux
+```
+
+**Important:** Ports of different TutoProxy.Client instances must not overlap. Each client serves a unique set of ports.
+
+---
+
+### Traffic Flow Architecture
+
+#### Request Flow (External Client -> Target Host)
+
+**TutoProxy.Server side:**
+1. External Client sends data to TutoProxy.Server
+2. `TcpServer` / `UdpServer` receives incoming data
+3. `TcpServer` / `UdpServer` passes data to `TcpClient` / `UdpClient`
+4. `TcpClient` / `UdpClient` sends data via `DataTransferService` to `SignalRHub`
+
+**TutoProxy.Client side:**
+1. `SignalRClient` receives `TcpRequest` / `UdpRequest` and passes to `TcpClient` / `UdpClient`
+2. `TcpClient` / `UdpClient` sends data to Target Host
+
+#### Response Flow (Target Host -> External Client)
+
+**TutoProxy.Client side:**
+1. Target Host sends response data
+2. `TcpClient` / `UdpClient` receives response
+3. `TcpClient` / `UdpClient` passes response to `SignalRClient` (`SendTcpResponse` / `SendUdpResponse`)
+4. `SignalRClient` sends data to TutoProxy.Server
+
+**TutoProxy.Server side:**
+1. `SignalRHub` receives `TcpResponse` / `UdpResponse`
+2. `DataTransferService` finds corresponding `HubClient` and passes response to it
+3. `HubClient` finds `TcpServer` / `UdpServer` by port
+4. `TcpServer` / `UdpServer` finds `TcpClient` / `UdpClient` by origin port
+5. `TcpClient` / `UdpClient` sends response via socket to External Client
+
+#### Component Responsibilities
+
+**TutoProxy.Server:**
+- `SignalRHub` - SignalR hub, communication with TutoProxy.Client
+- `DataTransferService` - routes data between SignalRHub and HubClients
+- `HubClient` - represents connected TutoProxy.Client, contains TcpServers/UdpServers
+- `TcpServer` / `UdpServer` - listen on ports, manage client sessions
+- `TcpClient` / `UdpClient` - handle individual external client sessions
+- `HubClientsService` - manage HubClient instances, validate ports and client IDs
+
+**TutoProxy.Client:**
+- `SignalRClient` - connection to TutoProxy.Server, receives requests, sends responses
+- `TcpClient` / `UdpClient` - connect to target host, forward data
+- `ClientsService` - manage active connections
+
+---
 
 ### Performance Testing
 

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ TutoProxy.Server http://200.100.10.1:8088 \
 | `--id <id>` | Yes | Unique client identifier. Must match allowed clients on server if restriction is enabled |
 | `--tcp <ports>` | No* | TCP ports to handle. Must be subset of server's TCP ports. Example: `--tcp=80,443` |
 | `--udp <ports>` | No* | UDP ports to handle. Must be subset of server's UDP ports. Example: `--udp=5000-5005` |
+| `--protocol <mode>` | No | Transport protocol: `Auto` (default), `Http`, `WebSocket`. WebSocket mode skips negotiation for faster connection |
 | `--daemon` | No | Run in daemon mode without terminal GUI, reduces CPU overhead |
 
 *At least one of `--tcp` or `--udp` must be specified.
@@ -173,17 +174,17 @@ The project includes a performance testing script that measures tunnel throughpu
 #### Usage
 
 ```bash
-# Full test (baseline + tunnel)
+# Full test (Auto + Http + WebSocket protocols)
 ./Projects/TutoProxy/scripts/perf-test.sh full
 
-# Tunnel test only (10 seconds)
-./Projects/TutoProxy/scripts/perf-test.sh tunnel -d 10
+# WebSocket protocol test (fastest, skips negotiation)
+./Projects/TutoProxy/scripts/perf-test.sh websocket -d 10
 
-# Tunnel test with parallel streams
-./Projects/TutoProxy/scripts/perf-test.sh tunnel -d 30 -p 4
+# Auto protocol test with parallel streams
+./Projects/TutoProxy/scripts/perf-test.sh auto -d 30 -p 4
 
-# Baseline test only (direct to iperf3, no tunnel)
-./Projects/TutoProxy/scripts/perf-test.sh baseline -d 10
+# Http protocol test (LongPolling)
+./Projects/TutoProxy/scripts/perf-test.sh http -d 10
 ```
 
 #### VSCode Tasks

--- a/README.md
+++ b/README.md
@@ -70,6 +70,18 @@ TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 \
 
 #### Request Flow (External Client -> Target Host)
 
+```
+┌─────────────┐      ┌─────────────────────────────────────────────┐      ┌─────────────────────────────────────────┐       ┌─────────────┐
+│  EXTERNAL   │      │               TUTOPROXY.SERVER              │      │           TUTOPROXY.CLIENT              │       │   TARGET    │
+│   CLIENT    │      │                                             │      │                                         │       │    HOST     │
+└──────┬──────┘      └─────────────────────────────────────────────┘      └─────────────────────────────────────────┘       └──────▲──────┘
+       │                                                                                                                           │
+       │  ┌──────────┐  ┌──────────┐  ┌────────────────────┐  ┌───────────┐        ┌──────────────┐  ┌──────────────┐  ┌──────────┐│
+       └─►│TcpServer │─►│TcpClient │─►│DataTransferService │─►│SignalRHub │───────►│SignalRClient │─►│ClientsService│─►│TcpClient │┘
+          │UdpServer │  │UdpClient │  │                    │  │           │SignalR │              │  │              │  │UdpClient │
+          └──────────┘  └──────────┘  └────────────────────┘  └───────────┘        └──────────────┘  └──────────────┘  └──────────┘
+```
+
 **TutoProxy.Server side:**
 1. External Client sends data to TutoProxy.Server
 2. `TcpServer` / `UdpServer` receives incoming data
@@ -81,6 +93,19 @@ TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 \
 2. `TcpClient` / `UdpClient` sends data to Target Host
 
 #### Response Flow (Target Host -> External Client)
+
+```
+┌─────────────┐      ┌─────────────────────────────────────────────┐      ┌─────────────────────────────────────────┐       ┌─────────────┐
+│  EXTERNAL   │      │               TUTOPROXY.SERVER              │      │           TUTOPROXY.CLIENT              │       │   TARGET    │
+│   CLIENT    │      │                                             │      │                                         │       │    HOST     │
+└──────▲──────┘      └─────────────────────────────────────────────┘      └─────────────────────────────────────────┘       └──────┬──────┘
+       │                                                                                                                           │
+       │  ┌──────────┐  ┌──────────┐  ┌────────────────────┐  ┌───────────┐        ┌──────────────┐                    ┌──────────┐│
+       └──│TcpServer │◄─│TcpClient │◄─│DataTransferService │◄─│SignalRHub │◄───────│SignalRClient │◄───────────────────│TcpClient │┘
+          │UdpServer │  │UdpClient │  │                    │  │           │SignalR │              │                    │UdpClient │
+          └──────────┘  └──────────┘  └────────────────────┘  └───────────┘        └──────────────┘                    └──────────┘
+
+```
 
 **TutoProxy.Client side:**
 1. Target Host sends response data


### PR DESCRIPTION
This PR implements a series of SignalR optimizations to improve type safety, reduce runtime overhead, and add transport protocol configurability. Building on the existing MessagePack serialization, these changes eliminate string-based method invocations and leverage compile-time code generation.

### Key Changes

#### 1. Typed SignalR Hub (Server-side)

Converted `SignalRHub` from `Hub` to `Hub<IClientHub>` for compile-time method verification on server-to-client calls.

**Key files**: `TutoProxy.Server/Communication/SignalRHub.cs`, `TuToProxy.Core/IClientHub.cs`

```csharp
// Before
await Clients.Caller.SendAsync("Errors", ex.Message);

// After
await Clients.Caller.Errors(ex.Message);

```

Note: Methods with client return values (`ConnectTcp`, `TcpRequest`, `DisconnectTcp`) still use `InvokeAsync` with `ClientMethods` constants, as typed hubs don't support the Client Results pattern.

#### 2. TypedSignalR.Client Source Generator (Client-side)

Added [TypedSignalR.Client](https://github.com/nenoNaninu/TypedSignalR.Client) for compile-time generated SignalR client proxies.

**Key files**: `TutoProxy.Client/Communication/SignalRClient.cs`, `TuToProxy.Core/IClientHub.cs`

New interfaces:

-   `IServerHub`  - client-to-server method calls
-   `IClientReceiver`  - server-to-client method handlers (including client results)

```csharp
// Before
await connection.SendAsync("UdpResponse", response, cancellationToken);

// After
await hubProxy.UdpResponse(response);

```

#### 3. Configurable Transport Protocol

Added `--protocol` command-line option for TutoProxy.Client with values: `Auto` (default), `Http` (LongPolling), `WebSocket`.

**Key files**: `TutoProxy.Client/CommandLine/AppRootCommand.cs`, `TuToProxy.Core/TransportProtocol.cs`

WebSocket mode enables `SkipNegotiation` for faster connection establishment.

#### 4. FrozenDictionary for Server Lookups

Replaced `Dictionary` with `FrozenDictionary` in `HubClient` for immutable, read-optimized server collections.

**Key files**: `TutoProxy.Server/Communication/HubClient.cs`

#### 5. Simplified Banned Ports Check

Refactored `GetBannedPorts` to `HasBannedPorts` with early-exit boolean logic, avoiding multiple enumeration.

**Key files**: `TutoProxy.Server/Services/HubClientsService.cs`

#### 6. Code Cleanup

Removed unused `clientProxy` parameter from `HubClient` and `HubClientsService.Connect()`.

#### 7. Performance Test Updates

Updated `perf-test.sh` to support protocol-specific testing: `auto`, `http`, `websocket`, `full`.

**Key files**: `scripts/perf-test.sh`, `.vscode/tasks.json`

#### 8. Tests

Updated all affected tests to work with new typed interfaces and removed mock dependencies.