### PR TITLE
Concurrent: Parallel SignalR Connections for Improved TCP Throughput

### DIFF
--- a/.github/workflows/dotnet.yml
+++ b/.github/workflows/dotnet.yml
@@ -29,8 +29,14 @@ jobs:
       run: dotnet build ./Projects/TutoProxy/TutoProxy.sln --no-restore
     - name: Unit Tests
       run: dotnet test ./Projects/TutoProxy/TutoProxy.sln --no-build --verbosity normal
-    - name: Perfomance Tests
+    - name: Perfomance Tests (1 connection)
       run: ./Projects/TutoProxy/scripts/perf-test.sh full -d 10
+    - name: Perfomance Tests (1 connection, reverse)
+      run: ./Projects/TutoProxy/scripts/perf-test.sh full-reverse -d 10
+    - name: Perfomance Tests (4 parallel connections)
+      run: ./Projects/TutoProxy/scripts/perf-test.sh full -d 10 -p 4 -s 4
+    - name: Perfomance Tests (4 parallel connections, reverse)
+      run: ./Projects/TutoProxy/scripts/perf-test.sh full-reverse -d 10 -p 4 -s 4
 
     - name: Publish
       run: |

--- a/.gitignore
+++ b/.gitignore
@@ -17,4 +17,7 @@ Projects/TutoProxy/TestClients/UdpClient/log*.txt
 out/*
 **/3proxy/*
 **/BenchmarkDotNet.Artifacts/*
+**/profiles/*
+*.nettrace
+*.speedscope.json
 log-*.txt

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -24,11 +24,10 @@
             "request": "launch",
             "program": "${workspaceFolder}/Projects/TutoProxy/TutoProxy.Client/bin/Debug/net10.0/TutoProxy.Client.dll",
             "args": [
-                "http://127.0.0.1:5088",
+                "http://192.168.0.107:8088",
                 "127.0.0.1",
-                "--tcp=5201",
-                "--udp=5201",
-                "--id=TestClient",
+                "--tcp=8001",
+                "--id=ClientSec",
                 "--protocol=Auto",
                 "--parallel=4"
             ],

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -1,0 +1,40 @@
+{
+    // Use IntelliSense to learn about possible attributes.
+    // Hover to view descriptions of existing attributes.
+    // For more information, visit: https://go.microsoft.com/fwlink/?linkid=830387
+    "version": "0.2.0",
+    "configurations": [
+        {
+            "name": "Server",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/Projects/TutoProxy/TutoProxy.Server/bin/Debug/net10.0/TutoProxy.Server.dll",
+            "args": [
+                "http://127.0.0.1:5088",
+                "--tcp=5201",
+                "--udp=5201"
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
+        },
+        {
+            "name": "Client",
+            "type": "coreclr",
+            "request": "launch",
+            "program": "${workspaceFolder}/Projects/TutoProxy/TutoProxy.Client/bin/Debug/net10.0/TutoProxy.Client.dll",
+            "args": [
+                "http://127.0.0.1:5088",
+                "127.0.0.1",
+                "--tcp=5201",
+                "--udp=5201",
+                "--id=TestClient",
+                "--protocol=Auto",
+                "--parallel=4"
+            ],
+            "cwd": "${workspaceFolder}",
+            "stopAtEntry": false,
+            "console": "integratedTerminal"
+        }
+    ]
+}

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -10,9 +10,10 @@
             "request": "launch",
             "program": "${workspaceFolder}/Projects/TutoProxy/TutoProxy.Server/bin/Debug/net10.0/TutoProxy.Server.dll",
             "args": [
-                "http://127.0.0.1:5088",
+                "http://172.31.182.199:8088",
                 "--tcp=5201",
-                "--udp=5201"
+                "--udp=5201",
+                "--clients=ClientSec"
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,
@@ -30,7 +31,7 @@
                 "--udp=5201",
                 "--id=ClientSec",
                 "--protocol=Auto",
-                "--parallel=1"
+                "--parallel=8"
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -26,10 +26,11 @@
             "args": [
                 "http://192.168.0.107:8088",
                 "127.0.0.1",
-                "--tcp=8001",
+                "--tcp=5201",
+                "--udp=5201",
                 "--id=ClientSec",
                 "--protocol=Auto",
-                "--parallel=4"
+                "--parallel=1"
             ],
             "cwd": "${workspaceFolder}",
             "stopAtEntry": false,

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -72,6 +72,18 @@
                 "panel": "new"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: TCP WebSocket + Profile (30s)",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["websocket", "--profile", "-d", "30"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
         }
     ]
 }

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -2,7 +2,7 @@
     "version": "2.0.0",
     "tasks": [
         {
-            "label": "Perf Test: Full (Auto + Http + WebSocket)",
+            "label": "Perf Test: TCP Full (Auto + Http + WebSocket)",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
             "args": ["full", "-d", "10"],
@@ -14,10 +14,10 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: Auto protocol",
+            "label": "Perf Test: TCP Full Reverse",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["auto", "-d", "10"],
+            "args": ["full-reverse", "-d", "10"],
             "group": "test",
             "presentation": {
                 "reveal": "always",
@@ -26,19 +26,7 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: Http protocol (LongPolling)",
-            "type": "shell",
-            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["http", "-d", "10"],
-            "group": "test",
-            "presentation": {
-                "reveal": "always",
-                "panel": "new"
-            },
-            "problemMatcher": []
-        },
-        {
-            "label": "Perf Test: WebSocket protocol (fastest)",
+            "label": "Perf Test: TCP WebSocket (fastest)",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
             "args": ["websocket", "-d", "10"],
@@ -50,10 +38,34 @@
             "problemMatcher": []
         },
         {
-            "label": "Perf Test: WebSocket (30s, 4 parallel)",
+            "label": "Perf Test: TCP WebSocket Reverse",
             "type": "shell",
             "command": "./Projects/TutoProxy/scripts/perf-test.sh",
-            "args": ["websocket", "-d", "30", "-p", "4"],
+            "args": ["websocket-reverse", "-d", "10"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: UDP Full (Auto + Http + WebSocket)",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["udp-full", "-d", "10", "-b", "1000M"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: UDP Full Reverse",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["udp-full-reverse", "-d", "10", "-b", "1000M"],
             "group": "test",
             "presentation": {
                 "reveal": "always",

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -84,6 +84,30 @@
                 "panel": "new"
             },
             "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: TCP WebSocket 4-Channel",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["websocket", "-d", "10", "-s", "4", "-p", "4"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
+        },
+        {
+            "label": "Perf Test: TCP WebSocket 4-Channel Reverse",
+            "type": "shell",
+            "command": "./Projects/TutoProxy/scripts/perf-test.sh",
+            "args": ["websocket-reverse", "-d", "10", "-s", "4", "-p", "4"],
+            "group": "test",
+            "presentation": {
+                "reveal": "always",
+                "panel": "new"
+            },
+            "problemMatcher": []
         }
     ]
 }

--- a/Projects/TutoProxy/TestClients/TcpClient/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TestClients/TcpClient/CommandLine/AppRootCommand.cs
@@ -1,74 +1,69 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
-using Microsoft.Extensions.Hosting;
 using TuToProxy.Core.Extensions;
 
 namespace TutoProxy.Server.CommandLine {
     internal class AppRootCommand : RootCommand {
         const string description = "Тестовый tcp-клиент";
+
+        public Argument<string> IpArg { get; }
+        public Argument<int> PortArg { get; }
+        public Argument<int> DelayArg { get; }
+        public Argument<int> PacketArg { get; }
+
         public AppRootCommand() : base(description) {
-            Add(new Argument<string>("ip", "Remote TCP IP address"));
-            Add(new Argument<int>("port", "Remote TCP IP port"));
-            var argDelay = new Argument<int>("delay", () => 1000, "Delay before repeat, ms. Min value is 0ms");
-            Add(argDelay);
-            var argPacketSize = new Argument<int>("packet", () => 1400, "Packet size, bytes. Min value is 1");
-            Add(argPacketSize);
-            AddValidator((result) => {
+            IpArg = new Argument<string>("ip") { Description = "Remote TCP IP address" };
+            PortArg = new Argument<int>("port") { Description = "Remote TCP IP port" };
+            DelayArg = new Argument<int>("delay") { Description = "Delay before repeat, ms. Min value is 0ms", DefaultValueFactory = _ => 1000 };
+            PacketArg = new Argument<int>("packet") { Description = "Packet size, bytes. Min value is 1", DefaultValueFactory = _ => 1400 };
+
+            Add(IpArg);
+            Add(PortArg);
+            Add(DelayArg);
+            Add(PacketArg);
+
+            Validators.Add((result) => {
                 try {
-                    if(result.Children.Any(x => x.GetValueForArgument(argDelay) < 0)) {
-                        result.ErrorMessage = "Delay should be higher or equal than 0ms";
+                    if(result.Children.Any(x => x.GetValue(DelayArg) < 0)) {
+                        result.AddError("Delay should be higher or equal than 0ms");
                         return;
                     }
-                    if(result.Children.Any(x => x.GetValueForArgument(argPacketSize) < 1)) {
-                        result.ErrorMessage = "The packet size must be greater than or equal to 1 byte.";
+                    if(result.Children.Any(x => x.GetValue(PacketArg) < 1)) {
+                        result.AddError("The packet size must be greater than or equal to 1 byte.");
                         return;
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly ILogger logger;
-            readonly IHostApplicationLifetime applicationLifetime;
+        public void ConfigureAction(Serilog.ILogger logger, CancellationToken applicationStopping) {
+            SetAction(async (parseResult, cancellationToken) => {
+                var ip = parseResult.GetValue(IpArg)!;
+                var port = parseResult.GetValue(PortArg);
+                var delay = parseResult.GetValue(DelayArg);
+                var packet = parseResult.GetValue(PacketArg);
 
-            public string Ip { get; set; } = string.Empty;
-            public int Port { get; set; }
-            public int Delay { get; set; }
-            public int Packet { get; set; }
-
-            public Handler(
-                ILogger logger,
-                IHostApplicationLifetime applicationLifetime
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                this.logger = logger;
-                this.applicationLifetime = applicationLifetime;
-            }
-
-            public async Task<int> InvokeAsync(InvocationContext context) {
-                var remoteEndPoint = new IPEndPoint(IPAddress.Parse(Ip), Port);
+                var remoteEndPoint = new IPEndPoint(IPAddress.Parse(ip), port);
 
                 logger.Information($"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}");
-                logger.Information($"{description}, ip: {Ip}, порт: {Port}, delay: {Delay}");
+                logger.Information($"{description}, ip: {ip}, порт: {port}, delay: {delay}");
 
-                while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
+                while(!applicationStopping.IsCancellationRequested) {
                     using(var tcpClient = new Socket(remoteEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp)) {
                         int localPort = -1;
                         try {
-                            await tcpClient.ConnectAsync(remoteEndPoint, applicationLifetime.ApplicationStopping);
+                            await tcpClient.ConnectAsync(remoteEndPoint, applicationStopping);
                             localPort = (tcpClient.LocalEndPoint as IPEndPoint)!.Port;
                             logger.Information($"tcp({localPort}) success connected");
 
                         } catch(SocketException) {
                             logger.Warning($"tcp({localPort}) connect to {remoteEndPoint} timeout");
-                            await Task.Delay(5_000, applicationLifetime.ApplicationStopping);
+                            await Task.Delay(5_000, applicationStopping);
                             continue;
                         }
 
@@ -78,13 +73,13 @@ namespace TutoProxy.Server.CommandLine {
                         int packetsCount = 0;
                         int errors = 0;
 
-                        Memory<byte> receiveBuffer = new byte[Math.Max(16384, Packet)];
+                        Memory<byte> receiveBuffer = new byte[Math.Max(16384, packet)];
 
-                        using var cts = CancellationTokenSource.CreateLinkedTokenSource(applicationLifetime.ApplicationStopping);
-                        while(!applicationLifetime.ApplicationStopping.IsCancellationRequested && tcpClient.Connected) {
-                            var dataPacket = Enumerable.Repeat(Guid.NewGuid().ToByteArray(), (Packet / 16) + 1)
+                        using var cts = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
+                        while(!applicationStopping.IsCancellationRequested && tcpClient.Connected) {
+                            var dataPacket = Enumerable.Repeat(Guid.NewGuid().ToByteArray(), (packet / 16) + 1)
                                 .SelectMany(x => x)
-                                .Take(Packet).ToArray();
+                                .Take(packet).ToArray();
                             sRateStopWatch.Restart();
                             try {
                                 var txCount = await tcpClient.SendAsync(dataPacket, SocketFlags.None, cts.Token);
@@ -110,21 +105,21 @@ namespace TutoProxy.Server.CommandLine {
                                     errors = 0;
                                 } else {
                                     logger.Warning($"tcp({localPort}) response from {tcpClient.RemoteEndPoint}, bytes:{data.ToShortDescriptions()}. Wrong");
-                                    await Task.Delay(TimeSpan.FromMilliseconds(2000), applicationLifetime.ApplicationStopping);
+                                    await Task.Delay(TimeSpan.FromMilliseconds(2000), applicationStopping);
                                     if(errors++ > 3) {
                                         break;
                                     }
                                 }
                             } catch(Exception ex) when(ex is SocketException || ex is OperationCanceledException) {
                                 logger.Warning($"tcp({localPort}) response error");
-                                await Task.Delay(TimeSpan.FromMilliseconds(1000), applicationLifetime.ApplicationStopping);
+                                await Task.Delay(TimeSpan.FromMilliseconds(1000), applicationStopping);
                                 if(errors++ > 3) {
                                     break;
                                 }
                             }
 
-                            if(Delay > 0) {
-                                await Task.Delay(Delay, applicationLifetime.ApplicationStopping);
+                            if(delay > 0) {
+                                await Task.Delay(delay, applicationStopping);
                             }
                         }
                         logger.Warning($"tcp({localPort}) disconnecting");
@@ -132,7 +127,7 @@ namespace TutoProxy.Server.CommandLine {
                 }
 
                 return 0;
-            }
+            });
         }
     }
 }

--- a/Projects/TutoProxy/TestClients/TcpClient/Program.cs
+++ b/Projects/TutoProxy/TestClients/TcpClient/Program.cs
@@ -1,22 +1,28 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TutoProxy.Server.CommandLine;
 
 class Program {
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
-                )
+        using var host = Host.CreateDefaultBuilder(args)
+            .UseSerilog((_, config) => config
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
+                .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
             )
-            .UseDefaults()
             .Build();
-        return await runner.InvokeAsync(args);
+
+        await host.StartAsync();
+
+        var logger = host.Services.GetRequiredService<Serilog.ILogger>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger, applicationLifetime.ApplicationStopping);
+
+        var parseResult = command.Parse(args);
+        var result = await parseResult.InvokeAsync();
+
+        await host.StopAsync();
+        return result;
     }
 }

--- a/Projects/TutoProxy/TestClients/TcpServer/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TestClients/TcpServer/CommandLine/AppRootCommand.cs
@@ -1,63 +1,57 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
-using Microsoft.Extensions.Hosting;
 using TuToProxy.Core;
 using TuToProxy.Core.Extensions;
 
 namespace TutoProxy.Server.CommandLine {
     internal class AppRootCommand : RootCommand {
         const string description = "Тестовый tcp-сервер";
+
+        public Argument<string> IpArg { get; }
+        public Argument<int> PortArg { get; }
+        public Argument<int> DelayArg { get; }
+
         public AppRootCommand() : base(description) {
-            Add(new Argument<string>("ip", "Listen TCP IP address"));
-            Add(new Argument<int>("port", "Listen TCP IP port"));
-            var argDelay = new Argument<int>("delay", () => 10, "Delay before response, ms. Min value is 0ms");
-            Add(argDelay);
-            AddValidator((result) => {
+            IpArg = new Argument<string>("ip") { Description = "Listen TCP IP address" };
+            PortArg = new Argument<int>("port") { Description = "Listen TCP IP port" };
+            DelayArg = new Argument<int>("delay") { Description = "Delay before response, ms. Min value is 0ms", DefaultValueFactory = _ => 10 };
+
+            Add(IpArg);
+            Add(PortArg);
+            Add(DelayArg);
+
+            Validators.Add((result) => {
                 try {
-                    if(result.Children.Any(x => x.GetValueForArgument(argDelay) < 0)) {
-                        result.ErrorMessage = "Delay should be higher or equal than 0ms";
+                    if(result.Children.Any(x => x.GetValue(DelayArg) < 0)) {
+                        result.AddError("Delay should be higher or equal than 0ms");
                         return;
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly ILogger logger;
-            readonly IHostApplicationLifetime applicationLifetime;
+        public void ConfigureAction(Serilog.ILogger logger, CancellationToken applicationStopping) {
+            SetAction(async (parseResult, cancellationToken) => {
+                var ip = parseResult.GetValue(IpArg)!;
+                var port = parseResult.GetValue(PortArg);
+                var delay = parseResult.GetValue(DelayArg);
 
-            public string Ip { get; set; } = string.Empty;
-            public int Port { get; set; }
-            public int Delay { get; set; }
-
-            public Handler(
-                ILogger logger,
-                IHostApplicationLifetime applicationLifetime
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                this.logger = logger;
-                this.applicationLifetime = applicationLifetime;
-            }
-
-            public async Task<int> InvokeAsync(InvocationContext context) {
                 logger.Information($"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}");
-                logger.Information($"{description}, ip: {Ip}, порт: {Port}, delay: {Delay}");
+                logger.Information($"{description}, ip: {ip}, порт: {port}, delay: {delay}");
 
-                while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
-                    var tcpServer = new TcpListener(IPAddress.Parse(Ip), Port);
+                while(!applicationStopping.IsCancellationRequested) {
+                    var tcpServer = new TcpListener(IPAddress.Parse(ip), port);
                     tcpServer.Start();
                     try {
-                        while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
-                            var socket = await tcpServer.AcceptSocketAsync(applicationLifetime.ApplicationStopping);
+                        while(!applicationStopping.IsCancellationRequested) {
+                            var socket = await tcpServer.AcceptSocketAsync(applicationStopping);
 
                             logger.Information($"tcp accept {socket.RemoteEndPoint}");
-                            _ = Task.Run(async () => await HandleSocketAsync(socket, applicationLifetime.ApplicationStopping));
+                            _ = Task.Run(async () => await HandleSocketAsync(socket, delay, logger, applicationStopping));
                         }
                     } catch(SocketException ex) {
                         logger.Error(ex.Message);
@@ -67,33 +61,34 @@ namespace TutoProxy.Server.CommandLine {
                     }
                 }
                 return 0;
-            }
+            });
+        }
 
-            async Task HandleSocketAsync(Socket socket, CancellationToken cancellationToken) {
-                Memory<byte> receiveBuffer = new byte[TcpSocketParams.ReceiveBufferSize];
+        static async Task HandleSocketAsync(Socket socket, int delay, Serilog.ILogger logger, CancellationToken cancellationToken) {
+            Memory<byte> receiveBuffer = new byte[TcpSocketParams.ReceiveBufferSize];
+            var port = (socket.LocalEndPoint as IPEndPoint)!.Port;
 
-                try {
-                    var logTimer = DateTime.Now.AddSeconds(1);
-                    while(socket.Connected) {
-                        var receivedBytes = await socket.ReceiveAsync(receiveBuffer, SocketFlags.None, cancellationToken);
-                        if(receivedBytes == 0) {
-                            break;
-                        }
-                        var data = receiveBuffer[..receivedBytes].ToArray();
-                        if(logTimer <= DateTime.Now) {
-                            logTimer = DateTime.Now.AddSeconds(1);
-                            logger.Information($"tcp({Port}) request from {(IPEndPoint)socket.RemoteEndPoint!}, bytes:{data.ToShortDescriptions()}");
-                        }
-                        if(Delay > 0) {
-                            await Task.Delay(Delay);
-                        }
-                        var txCount = await socket.SendAsync(data, SocketFlags.None, cancellationToken);
+            try {
+                var logTimer = DateTime.Now.AddSeconds(1);
+                while(socket.Connected) {
+                    var receivedBytes = await socket.ReceiveAsync(receiveBuffer, SocketFlags.None, cancellationToken);
+                    if(receivedBytes == 0) {
+                        break;
                     }
-                } catch(SocketException ex) {
-                    logger.Error($"socket: {ex.Message}");
+                    var data = receiveBuffer[..receivedBytes].ToArray();
+                    if(logTimer <= DateTime.Now) {
+                        logTimer = DateTime.Now.AddSeconds(1);
+                        logger.Information($"tcp({port}) request from {(IPEndPoint)socket.RemoteEndPoint!}, bytes:{data.ToShortDescriptions()}");
+                    }
+                    if(delay > 0) {
+                        await Task.Delay(delay);
+                    }
+                    var txCount = await socket.SendAsync(data, SocketFlags.None, cancellationToken);
                 }
-                logger.Information($"tcp disconnected {socket.RemoteEndPoint}");
+            } catch(SocketException ex) {
+                logger.Error($"socket: {ex.Message}");
             }
+            logger.Information($"tcp disconnected {socket.RemoteEndPoint}");
         }
     }
 }

--- a/Projects/TutoProxy/TestClients/TcpServer/Program.cs
+++ b/Projects/TutoProxy/TestClients/TcpServer/Program.cs
@@ -1,22 +1,28 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TutoProxy.Server.CommandLine;
 
 class Program {
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
-                )
+        using var host = Host.CreateDefaultBuilder(args)
+            .UseSerilog((_, config) => config
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
+                .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
             )
-            .UseDefaults()
             .Build();
-        return await runner.InvokeAsync(args);
+
+        await host.StartAsync();
+
+        var logger = host.Services.GetRequiredService<Serilog.ILogger>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger, applicationLifetime.ApplicationStopping);
+
+        var parseResult = command.Parse(args);
+        var result = await parseResult.InvokeAsync();
+
+        await host.StopAsync();
+        return result;
     }
 }

--- a/Projects/TutoProxy/TestClients/UdpClient/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TestClients/UdpClient/CommandLine/AppRootCommand.cs
@@ -1,67 +1,63 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Diagnostics;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
-using Microsoft.Extensions.Hosting;
 using TuToProxy.Core.Extensions;
 
 namespace TutoProxy.Server.CommandLine {
     internal class AppRootCommand : RootCommand {
         const string description = "Тестовый udp-клиент";
+
+        public Argument<string> IpArg { get; }
+        public Argument<int> PortArg { get; }
+        public Argument<int> DelayArg { get; }
+        public Argument<int> PacketArg { get; }
+        public Option<bool> FirenforgetOpt { get; }
+
         public AppRootCommand() : base(description) {
-            Add(new Argument<string>("ip", "Remote UDP IP address"));
-            Add(new Argument<int>("port", "Remote UDP IP port"));
-            var argDelay = new Argument<int>("delay", () => 1000, "Delay before repeat, ms. Min value is 0ms");
-            Add(argDelay);
-            var argPacketSize = new Argument<int>("packet", () => 1400, "Packet size, bytes. Min value is 1");
-            Add(argPacketSize);
-            Add(new Option<bool>("--firenforget", () => false, "Fire'n'Forget"));
-            AddValidator((result) => {
+            IpArg = new Argument<string>("ip") { Description = "Remote UDP IP address" };
+            PortArg = new Argument<int>("port") { Description = "Remote UDP IP port" };
+            DelayArg = new Argument<int>("delay") { Description = "Delay before repeat, ms. Min value is 0ms", DefaultValueFactory = _ => 1000 };
+            PacketArg = new Argument<int>("packet") { Description = "Packet size, bytes. Min value is 1", DefaultValueFactory = _ => 1400 };
+            FirenforgetOpt = new Option<bool>("--firenforget") { Description = "Fire'n'Forget", DefaultValueFactory = _ => false };
+
+            Add(IpArg);
+            Add(PortArg);
+            Add(DelayArg);
+            Add(PacketArg);
+            Add(FirenforgetOpt);
+
+            Validators.Add((result) => {
                 try {
-                    if(result.Children.Any(x => x.GetValueForArgument(argDelay) < 0)) {
-                        result.ErrorMessage = "Delay should be higher or equal than 0ms";
+                    if(result.Children.Any(x => x.GetValue(DelayArg) < 0)) {
+                        result.AddError("Delay should be higher or equal than 0ms");
                         return;
                     }
-                    if(result.Children.Any(x => x.GetValueForArgument(argPacketSize) < 1)) {
-                        result.ErrorMessage = "The packet size must be greater than or equal to 1 byte.";
+                    if(result.Children.Any(x => x.GetValue(PacketArg) < 1)) {
+                        result.AddError("The packet size must be greater than or equal to 1 byte.");
                         return;
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly ILogger logger;
-            readonly IHostApplicationLifetime applicationLifetime;
+        public void ConfigureAction(Serilog.ILogger logger, CancellationToken applicationStopping) {
+            SetAction(async (parseResult, cancellationToken) => {
+                var ip = parseResult.GetValue(IpArg)!;
+                var port = parseResult.GetValue(PortArg);
+                var delay = parseResult.GetValue(DelayArg);
+                var packet = parseResult.GetValue(PacketArg);
+                var firenforget = parseResult.GetValue(FirenforgetOpt);
 
-            public string Ip { get; set; } = string.Empty;
-            public int Port { get; set; }
-            public int Delay { get; set; }
-            public int Packet { get; set; }
-            public bool Firenforget { get; set; }
-
-            public Handler(
-                ILogger logger,
-                IHostApplicationLifetime applicationLifetime
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                this.logger = logger;
-                this.applicationLifetime = applicationLifetime;
-            }
-
-            public async Task<int> InvokeAsync(InvocationContext context) {
-                var serverEndPoint = new IPEndPoint(IPAddress.Parse(Ip), Port);
+                var serverEndPoint = new IPEndPoint(IPAddress.Parse(ip), port);
 
                 logger.Information($"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}");
-                logger.Information($"{description}, ip: {Ip}, порт: {Port}, delay: {Delay}");
+                logger.Information($"{description}, ip: {ip}, порт: {port}, delay: {delay}");
 
-
-                while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
+                while(!applicationStopping.IsCancellationRequested) {
                     using var udpClient = new UdpClient(serverEndPoint.AddressFamily);
                     uint IOC_IN = 0x80000000;
                     uint IOC_VENDOR = 0x18000000;
@@ -72,25 +68,23 @@ namespace TutoProxy.Server.CommandLine {
                     udpClient.Client.SendTimeout = 5000;
                     udpClient.Client.ReceiveTimeout = 30000;
 
-
-
                     var sRateStopWatch = new Stopwatch();
                     var logTimer = DateTime.Now.AddSeconds(1);
                     double sRate = 0;
                     int packetsCount = 0;
                     int errors = 0;
 
-                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(applicationLifetime.ApplicationStopping);
+                    using var cts = CancellationTokenSource.CreateLinkedTokenSource(applicationStopping);
                     while(!cts.IsCancellationRequested) {
-                        var dataPacket = Enumerable.Repeat(Guid.NewGuid().ToByteArray(), (Packet / 16) + 1)
+                        var dataPacket = Enumerable.Repeat(Guid.NewGuid().ToByteArray(), (packet / 16) + 1)
                             .SelectMany(x => x)
-                            .Take(Packet).ToArray();
+                            .Take(packet).ToArray();
                         sRateStopWatch.Restart();
                         var txCount = await udpClient.SendAsync(dataPacket, serverEndPoint, cts.Token);
 
                         var localPort = (udpClient.Client.LocalEndPoint as IPEndPoint)!.Port;
 
-                        if(!Firenforget) {
+                        if(!firenforget) {
                             try {
                                 cts.CancelAfter(TimeSpan.FromMilliseconds(30000));
 
@@ -117,7 +111,7 @@ namespace TutoProxy.Server.CommandLine {
                                     errors = 0;
                                 } else {
                                     logger.Warning($"udp({localPort}) response from {remoteEndPoint}, bytes:{receiveBuffer.ToShortDescriptions()}. Wrong");
-                                    await Task.Delay(TimeSpan.FromMilliseconds(2000), applicationLifetime.ApplicationStopping);
+                                    await Task.Delay(TimeSpan.FromMilliseconds(2000), applicationStopping);
                                     if(errors++ > 3) {
                                         errors = 0;
                                         break;
@@ -130,14 +124,14 @@ namespace TutoProxy.Server.CommandLine {
                             logger.Information($"udp({localPort}) request to {serverEndPoint}, bytes:{dataPacket.ToShortDescriptions()}");
                             await Task.Delay(10);
                         }
-                        if(Delay > 0) {
-                            await Task.Delay(Delay);
+                        if(delay > 0) {
+                            await Task.Delay(delay);
                         }
                     }
                 }
 
                 return 0;
-            }
+            });
         }
     }
 }

--- a/Projects/TutoProxy/TestClients/UdpClient/Program.cs
+++ b/Projects/TutoProxy/TestClients/UdpClient/Program.cs
@@ -1,22 +1,28 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TutoProxy.Server.CommandLine;
 
 class Program {
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
-                )
+        using var host = Host.CreateDefaultBuilder(args)
+            .UseSerilog((_, config) => config
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
+                .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
             )
-            .UseDefaults()
             .Build();
-        return await runner.InvokeAsync(args);
+
+        await host.StartAsync();
+
+        var logger = host.Services.GetRequiredService<Serilog.ILogger>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger, applicationLifetime.ApplicationStopping);
+
+        var parseResult = command.Parse(args);
+        var result = await parseResult.InvokeAsync();
+
+        await host.StopAsync();
+        return result;
     }
 }

--- a/Projects/TutoProxy/TestClients/UdpServer/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TestClients/UdpServer/CommandLine/AppRootCommand.cs
@@ -1,55 +1,49 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Net;
 using System.Net.Sockets;
 using System.Reflection;
-using Microsoft.Extensions.Hosting;
 using TuToProxy.Core.Extensions;
 
 namespace TutoProxy.Server.CommandLine {
     internal class AppRootCommand : RootCommand {
         const string description = "Тестовый udp-сервер";
+
+        public Argument<string> IpArg { get; }
+        public Argument<int> PortArg { get; }
+        public Argument<int> DelayArg { get; }
+
         public AppRootCommand() : base(description) {
-            Add(new Argument<string>("ip", "Listen UDP IP address"));
-            Add(new Argument<int>("port", "Listen UDP IP port"));
-            var argDelay = new Argument<int>("delay", () => 10, "Delay before response, ms. Min value is 0ms");
-            Add(argDelay);
-            AddValidator((result) => {
+            IpArg = new Argument<string>("ip") { Description = "Listen UDP IP address" };
+            PortArg = new Argument<int>("port") { Description = "Listen UDP IP port" };
+            DelayArg = new Argument<int>("delay") { Description = "Delay before response, ms. Min value is 0ms", DefaultValueFactory = _ => 10 };
+
+            Add(IpArg);
+            Add(PortArg);
+            Add(DelayArg);
+
+            Validators.Add((result) => {
                 try {
-                    if(result.Children.Any(x => x.GetValueForArgument(argDelay) < 0)) {
-                        result.ErrorMessage = "Delay should be higher or equal than 0ms";
+                    if(result.Children.Any(x => x.GetValue(DelayArg) < 0)) {
+                        result.AddError("Delay should be higher or equal than 0ms");
                         return;
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly ILogger logger;
-            readonly IHostApplicationLifetime applicationLifetime;
+        public void ConfigureAction(Serilog.ILogger logger, CancellationToken applicationStopping) {
+            SetAction(async (parseResult, cancellationToken) => {
+                var ip = parseResult.GetValue(IpArg)!;
+                var port = parseResult.GetValue(PortArg);
+                var delay = parseResult.GetValue(DelayArg);
 
-            public string Ip { get; set; } = string.Empty;
-            public int Port { get; set; }
-            public int Delay { get; set; }
-
-            public Handler(
-                ILogger logger,
-                IHostApplicationLifetime applicationLifetime
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                this.logger = logger;
-                this.applicationLifetime = applicationLifetime;
-            }
-
-            public async Task<int> InvokeAsync(InvocationContext context) {
                 logger.Information($"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}");
-                logger.Information($"{description}, ip: {Ip}, порт: {Port}, delay: {Delay}");
+                logger.Information($"{description}, ip: {ip}, порт: {port}, delay: {delay}");
 
-                while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
-                    using var udpServer = new UdpClient(new IPEndPoint(IPAddress.Parse(Ip), Port));
+                while(!applicationStopping.IsCancellationRequested) {
+                    using var udpServer = new UdpClient(new IPEndPoint(IPAddress.Parse(ip), port));
                     uint IOC_IN = 0x80000000;
                     uint IOC_VENDOR = 0x18000000;
                     uint SIO_UDP_CONNRESET = IOC_IN | IOC_VENDOR | 12;
@@ -58,16 +52,16 @@ namespace TutoProxy.Server.CommandLine {
 
                     try {
                         var logTimer = DateTime.Now.AddSeconds(1);
-                        while(!applicationLifetime.ApplicationStopping.IsCancellationRequested) {
-                            var result = await udpServer.ReceiveAsync(applicationLifetime.ApplicationStopping);
+                        while(!applicationStopping.IsCancellationRequested) {
+                            var result = await udpServer.ReceiveAsync(applicationStopping);
                             if(logTimer <= DateTime.Now) {
                                 logTimer = DateTime.Now.AddSeconds(1);
-                                logger.Information($"udp({Port}) request from {result.RemoteEndPoint}, bytes:{result.Buffer.ToShortDescriptions()}");
+                                logger.Information($"udp({port}) request from {result.RemoteEndPoint}, bytes:{result.Buffer.ToShortDescriptions()}");
                             }
-                            if(Delay > 0) {
-                                await Task.Delay(Delay);
+                            if(delay > 0) {
+                                await Task.Delay(delay);
                             }
-                            var txCount = await udpServer.SendAsync(result.Buffer, result.RemoteEndPoint, applicationLifetime.ApplicationStopping);
+                            var txCount = await udpServer.SendAsync(result.Buffer, result.RemoteEndPoint, applicationStopping);
                         }
                     } catch(SocketException ex) {
                         logger.Error(ex.Message);
@@ -75,7 +69,7 @@ namespace TutoProxy.Server.CommandLine {
                 }
 
                 return 0;
-            }
+            });
         }
     }
 }

--- a/Projects/TutoProxy/TestClients/UdpServer/Program.cs
+++ b/Projects/TutoProxy/TestClients/UdpServer/Program.cs
@@ -1,22 +1,28 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using TutoProxy.Server.CommandLine;
 
 class Program {
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
-                )
+        using var host = Host.CreateDefaultBuilder(args)
+            .UseSerilog((_, config) => config
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}")
+                .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day)
             )
-            .UseDefaults()
             .Build();
-        return await runner.InvokeAsync(args);
+
+        await host.StartAsync();
+
+        var logger = host.Services.GetRequiredService<Serilog.ILogger>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger, applicationLifetime.ApplicationStopping);
+
+        var parseResult = command.Parse(args);
+        var result = await parseResult.InvokeAsync();
+
+        await host.StopAsync();
+        return result;
     }
 }

--- a/Projects/TutoProxy/TuToProxy.Core.Tests/PoolingTests/DataModelPoolTests.cs
+++ b/Projects/TutoProxy/TuToProxy.Core.Tests/PoolingTests/DataModelPoolTests.cs
@@ -1,0 +1,101 @@
+using NUnit.Framework;
+using TuToProxy.Core.Models;
+using TuToProxy.Core.Pooling;
+
+namespace TuToProxy.Core.Tests.PoolingTests {
+    public class DataModelPoolTests {
+
+        [Test]
+        public void Rent_ReturnsNewInstance() {
+            var model = DataModelPool<TcpDataRequestModel>.Rent();
+
+            Assert.That(model, Is.Not.Null);
+            Assert.That(model, Is.InstanceOf<TcpDataRequestModel>());
+        }
+
+        [Test]
+        public void Rent_ReturnsInstanceWithDefaultValues() {
+            var model = DataModelPool<TcpDataRequestModel>.Rent();
+
+            Assert.That(model.Port, Is.EqualTo(0));
+            Assert.That(model.OriginPort, Is.EqualTo(0));
+            Assert.That(model.Data.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Return_ResetsModelValues() {
+            var model = DataModelPool<TcpDataRequestModel>.Rent();
+            model.Port = 8080;
+            model.OriginPort = 12345;
+            model.Data = new byte[] { 1, 2, 3 };
+
+            DataModelPool<TcpDataRequestModel>.Return(model);
+
+            Assert.That(model.Port, Is.EqualTo(0));
+            Assert.That(model.OriginPort, Is.EqualTo(0));
+            Assert.That(model.Data.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Return_ObjectIsReusedFromPool() {
+            var model1 = DataModelPool<TcpDataRequestModel>.Rent();
+            model1.Port = 1000;
+            model1.OriginPort = 2000;
+            model1.Data = new byte[] { 1, 2, 3 };
+
+            DataModelPool<TcpDataRequestModel>.Return(model1);
+
+            var model2 = DataModelPool<TcpDataRequestModel>.Rent();
+
+            Assert.That(model2, Is.SameAs(model1));
+            Assert.That(model2.Port, Is.EqualTo(0));
+            Assert.That(model2.OriginPort, Is.EqualTo(0));
+            Assert.That(model2.Data.IsEmpty, Is.True);
+        }
+
+        [Test]
+        public void Pool_WorksWithAllModelTypes() {
+            var tcpRequest = DataModelPool<TcpDataRequestModel>.Rent();
+            var tcpResponse = DataModelPool<TcpDataResponseModel>.Rent();
+            var udpRequest = DataModelPool<UdpDataRequestModel>.Rent();
+            var udpResponse = DataModelPool<UdpDataResponseModel>.Rent();
+
+            Assert.That(tcpRequest, Is.InstanceOf<TcpDataRequestModel>());
+            Assert.That(tcpResponse, Is.InstanceOf<TcpDataResponseModel>());
+            Assert.That(udpRequest, Is.InstanceOf<UdpDataRequestModel>());
+            Assert.That(udpResponse, Is.InstanceOf<UdpDataResponseModel>());
+
+            DataModelPool<TcpDataRequestModel>.Return(tcpRequest);
+            DataModelPool<TcpDataResponseModel>.Return(tcpResponse);
+            DataModelPool<UdpDataRequestModel>.Return(udpRequest);
+            DataModelPool<UdpDataResponseModel>.Return(udpResponse);
+        }
+
+        [Test]
+        public void Pool_EachTypeHasSeparatePool() {
+            var tcpRequest = DataModelPool<TcpDataRequestModel>.Rent();
+            var udpRequest = DataModelPool<UdpDataRequestModel>.Rent();
+
+            DataModelPool<TcpDataRequestModel>.Return(tcpRequest);
+            DataModelPool<UdpDataRequestModel>.Return(udpRequest);
+
+            var tcpRequest2 = DataModelPool<TcpDataRequestModel>.Rent();
+            var udpRequest2 = DataModelPool<UdpDataRequestModel>.Rent();
+
+            Assert.That(tcpRequest2, Is.SameAs(tcpRequest));
+            Assert.That(udpRequest2, Is.SameAs(udpRequest));
+            Assert.That(tcpRequest2, Is.Not.SameAs(udpRequest2));
+        }
+
+        [Test]
+        public void MultipleRent_WithoutReturn_CreatesNewInstances() {
+            var model1 = DataModelPool<TcpDataRequestModel>.Rent();
+            var model2 = DataModelPool<TcpDataRequestModel>.Rent();
+
+            Assert.That(model1, Is.Not.SameAs(model2));
+
+            DataModelPool<TcpDataRequestModel>.Return(model1);
+            DataModelPool<TcpDataRequestModel>.Return(model2);
+        }
+    }
+}

--- a/Projects/TutoProxy/TuToProxy.Core.Tests/TuToProxy.Core.Tests.csproj
+++ b/Projects/TutoProxy/TuToProxy.Core.Tests/TuToProxy.Core.Tests.csproj
@@ -8,10 +8,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Projects/TutoProxy/TuToProxy.Core/CommandLine/AllowedClientsOption.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/CommandLine/AllowedClientsOption.cs
@@ -17,22 +17,21 @@ namespace TuToProxy.Core.CommandLine {
         }
 
         public static Option<AllowedClientsOption?> Create(string name, string description) {
-            return new Option<AllowedClientsOption?>(
-                     name: name,
-                     parseArgument: (result) => {
-                         if(result.Tokens.Count != 1) {
-                             result.ErrorMessage = "Value only be parsed with single token";
-                             return default;
-                         }
-                         try {
-                             return Parse(result.Tokens[0].Value);
-                         } catch(ArgumentException exception) {
-                             result.ErrorMessage = exception.GetBaseException().Message;
-                             return default;
-                         }
-                     },
-                     description: description
-             );
+            return new Option<AllowedClientsOption?>(name) {
+                Description = description,
+                CustomParser = result => {
+                    if(result.Tokens.Count != 1) {
+                        result.AddError("Value only be parsed with single token");
+                        return default;
+                    }
+                    try {
+                        return Parse(result.Tokens[0].Value);
+                    } catch(ArgumentException exception) {
+                        result.AddError(exception.GetBaseException().Message);
+                        return default;
+                    }
+                }
+            };
         }
 
         public static AllowedClientsOption Parse(string? value) {

--- a/Projects/TutoProxy/TuToProxy.Core/CommandLine/PortsArgument.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/CommandLine/PortsArgument.cs
@@ -17,22 +17,21 @@ namespace TuToProxy.Core.CommandLine {
         }
 
         public static Option<PortsArgument?> CreateOption(string name, string description) {
-            return new Option<PortsArgument?>(
-                     name: name,
-                     parseArgument: (result) => {
-                         if(result.Tokens.Count != 1) {
-                             result.ErrorMessage = "Ports can only be parsed with single token";
-                             return default;
-                         }
-                         try {
-                             return PortsArgument.Parse(result.Tokens[0].Value);
-                         } catch(ArgumentException exception) {
-                             result.ErrorMessage = exception.GetBaseException().Message;
-                             return default;
-                         }
-                     },
-                     description: description
-             );
+            return new Option<PortsArgument?>(name) {
+                Description = description,
+                CustomParser = result => {
+                    if(result.Tokens.Count != 1) {
+                        result.AddError("Ports can only be parsed with single token");
+                        return default;
+                    }
+                    try {
+                        return PortsArgument.Parse(result.Tokens[0].Value);
+                    } catch(ArgumentException exception) {
+                        result.AddError(exception.GetBaseException().Message);
+                        return default;
+                    }
+                }
+            };
         }
 
         public static PortsArgument Parse(string? value) {

--- a/Projects/TutoProxy/TuToProxy.Core/Models/DataBaseModel.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/Models/DataBaseModel.cs
@@ -36,6 +36,11 @@ namespace TuToProxy.Core.Models {
         public override string ToString() {
             return $"port:{Port}, o-port:{OriginPort}";
         }
+
+        public virtual void Reset() {
+            Port = 0;
+            OriginPort = 0;
+        }
     }
 
     public abstract class DataBaseModel : SocketAddressModel {
@@ -71,6 +76,11 @@ namespace TuToProxy.Core.Models {
 
         public override string ToString() {
             return $"{base.ToString()}, {Data.Length} b";
+        }
+
+        public override void Reset() {
+            base.Reset();
+            Data = ReadOnlyMemory<byte>.Empty;
         }
     }
 }

--- a/Projects/TutoProxy/TuToProxy.Core/Pooling/DataModelPool.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/Pooling/DataModelPool.cs
@@ -1,0 +1,25 @@
+using Microsoft.Extensions.ObjectPool;
+using TuToProxy.Core.Models;
+
+namespace TuToProxy.Core.Pooling;
+
+public static class DataModelPool<T> where T : DataBaseModel, new() {
+    static readonly ObjectPool<T> pool =
+        new DefaultObjectPoolProvider().Create(new DataModelPoolPolicy<T>());
+
+    public static T Rent() => pool.Get();
+
+    public static void Return(T model) {
+        model.Reset();
+        pool.Return(model);
+    }
+}
+
+internal class DataModelPoolPolicy<T> : PooledObjectPolicy<T> where T : DataBaseModel, new() {
+    public override T Create() => new T();
+
+    public override bool Return(T obj) {
+        obj.Reset();
+        return true;
+    }
+}

--- a/Projects/TutoProxy/TuToProxy.Core/SignalRParams.cs
+++ b/Projects/TutoProxy/TuToProxy.Core/SignalRParams.cs
@@ -4,5 +4,7 @@
         public const string TcpQuery = "tcpquery";
         public const string UdpQuery = "udpquery";
         public const string ClientId = "clientid";
+        public const string ConnectionIndex = "connindex";
+        public const string TotalConnections = "totalconn";
     }
 }

--- a/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
+++ b/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
@@ -8,13 +8,13 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
-    <PackageReference Include="MessagePack" Version="3.1.3" />
-    <PackageReference Include="MessagePack.Annotations" Version="3.1.3" />
-    <PackageReference Include="Serilog" Version="4.2.0" />
-    <PackageReference Include="Serilog.Extensions.Hosting" Version="9.0.0" />
-    <PackageReference Include="Serilog.Sinks.Console" Version="6.0.0" />
-    <PackageReference Include="Serilog.Sinks.File" Version="6.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="10.0.3" />
+    <PackageReference Include="MessagePack" Version="3.1.4" />
+    <PackageReference Include="MessagePack.Annotations" Version="3.1.4" />
+    <PackageReference Include="Serilog" Version="4.3.1" />
+    <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
+    <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
+    <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
     <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
   </ItemGroup>

--- a/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
+++ b/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.File" Version="7.0.0" />
-    <PackageReference Include="System.CommandLine" Version="2.0.0-beta3.22114.1" />
-    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.22114.1" />
+    <PackageReference Include="System.CommandLine" Version="2.0.3" />
+    <PackageReference Include="System.CommandLine.Hosting" Version="0.4.0-alpha.25306.1" />
   </ItemGroup>
 
 </Project>

--- a/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
+++ b/Projects/TutoProxy/TuToProxy.Core/TuToProxy.Core.csproj
@@ -8,6 +8,7 @@
 
   <ItemGroup>
     <PackageReference Include="Guard.Net" Version="3.0.0" />
+    <PackageReference Include="Microsoft.Extensions.ObjectPool" Version="9.0.0" />
     <PackageReference Include="MessagePack" Version="3.1.3" />
     <PackageReference Include="MessagePack.Annotations" Version="3.1.3" />
     <PackageReference Include="Serilog" Version="4.2.0" />

--- a/Projects/TutoProxy/TutoProxy.Client.Tests/Services/TcpClientsServiceTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Client.Tests/Services/TcpClientsServiceTests.cs
@@ -17,6 +17,7 @@ namespace TutoProxy.Client.Tests.Services {
         Mock<IClientFactory> clientFactoryMock;
         Mock<IClientsService> clientsServiceMock;
         Mock<ISignalRClient> signalRClientMock;
+        Mock<ITcpDataChannel> tcpChannelMock;
         Mock<IProcessMonitor> processMonitorMock;
 
         TestableClientsService testable;
@@ -27,12 +28,13 @@ namespace TutoProxy.Client.Tests.Services {
             clientFactoryMock = new();
             clientsServiceMock = new();
             signalRClientMock = new();
+            tcpChannelMock = new();
             processMonitorMock = new();
 
             clientFactoryMock
-                .Setup(x => x.CreateTcp(It.IsAny<IPAddress>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IClientsService>(), It.IsAny<ISignalRClient>(), It.IsAny<IProcessMonitor>()))
-                .Returns<IPAddress, int, int, IClientsService, ISignalRClient, IProcessMonitor>((localIpAddress, port, originPort, clientsService, dataTunnelClient, processMonitor) => {
-                    return new TcpClient(new IPEndPoint(localIpAddress, port), originPort, loggerMock.Object, clientsServiceMock.Object, signalRClientMock.Object,
+                .Setup(x => x.CreateTcp(It.IsAny<IPAddress>(), It.IsAny<int>(), It.IsAny<int>(), It.IsAny<IClientsService>(), It.IsAny<ISignalRClient>(), It.IsAny<ITcpDataChannel>(), It.IsAny<IProcessMonitor>()))
+                .Returns<IPAddress, int, int, IClientsService, ISignalRClient, ITcpDataChannel, IProcessMonitor>((localIpAddress, port, originPort, clientsService, dataTunnelClient, tcpChannel, processMonitor) => {
+                    return new TcpClient(new IPEndPoint(localIpAddress, port), originPort, loggerMock.Object, clientsServiceMock.Object, signalRClientMock.Object, tcpChannelMock.Object,
                         processMonitorMock.Object);
                 });
 
@@ -43,15 +45,15 @@ namespace TutoProxy.Client.Tests.Services {
         public async Task AddTcpClient_With_Banned_TcpPort_Are_Throws_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1000, 4).ToList(), Enumerable.Range(1, 65535).ToList());
 
-            Assert.Throws<ClientNotFoundException>(() => testable.AddTcpClient(999, 50999, signalRClientMock.Object));
-            Assert.Throws<ClientNotFoundException>(() => testable.AddTcpClient(1005, 51005, signalRClientMock.Object));
+            Assert.Throws<ClientNotFoundException>(() => testable.AddTcpClient(999, 50999, signalRClientMock.Object, tcpChannelMock.Object));
+            Assert.Throws<ClientNotFoundException>(() => testable.AddTcpClient(1005, 51005, signalRClientMock.Object, tcpChannelMock.Object));
         }
 
         [Test]
         public async Task AddTcpClient_Only_Once_Creating_List_With_Same_Port_Clients_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4).ToList());
 
-            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object);
+            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object);
             Assert.That(client0, Is.Not.Null);
             Assert.That(client0.Port, Is.EqualTo(1000));
             Assert.That(client0.OriginPort, Is.EqualTo(51000));
@@ -60,7 +62,7 @@ namespace TutoProxy.Client.Tests.Services {
             Assert.That(testable.PublicMorozovTcpClients[1000].Keys, Is.EquivalentTo([51000]));
             Assert.That(testable.PublicMorozovTcpClients[1000][51000], Is.SameAs(client0));
 
-            var client1 = testable.AddTcpClient(1000, 51001, signalRClientMock.Object);
+            var client1 = testable.AddTcpClient(1000, 51001, signalRClientMock.Object, tcpChannelMock.Object);
             Assert.That(client1, Is.Not.Null);
             Assert.That(client1.Port, Is.EqualTo(1000));
             Assert.That(client1.OriginPort, Is.EqualTo(51001));
@@ -74,12 +76,12 @@ namespace TutoProxy.Client.Tests.Services {
         public async Task AddTcpClient_Only_Once_Creating_Same_Port_Client_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4).ToList());
 
-            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object);
+            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object);
             Assert.That(client0, Is.Not.Null);
             Assert.That(client0.Port, Is.EqualTo(1000));
             Assert.That(client0.OriginPort, Is.EqualTo(51000));
 
-            var client1 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object);
+            var client1 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object);
             Assert.That(client1, Is.SameAs(client0));
 
             Assert.That(testable.PublicMorozovTcpClients.Keys, Is.EquivalentTo([1000]));
@@ -99,8 +101,8 @@ namespace TutoProxy.Client.Tests.Services {
         public async Task ObtainTcpClient_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1000, 4).ToList(), Enumerable.Range(1, 65535).ToList());
 
-            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object);
-            var client1 = testable.AddTcpClient(1000, 51001, signalRClientMock.Object);
+            var client0 = testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object);
+            var client1 = testable.AddTcpClient(1000, 51001, signalRClientMock.Object, tcpChannelMock.Object);
 
             Assert.That(testable.ObtainTcpClient(1000, 50999, out _), Is.False);
 
@@ -117,8 +119,8 @@ namespace TutoProxy.Client.Tests.Services {
         public async Task RemoveTcpClient_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1000, 4).ToList(), Enumerable.Range(1, 65535).ToList());
 
-            Assert.That(testable.AddTcpClient(1000, 51000, signalRClientMock.Object), Is.Not.Null);
-            Assert.That(testable.AddTcpClient(1000, 51001, signalRClientMock.Object), Is.Not.Null);
+            Assert.That(testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object), Is.Not.Null);
+            Assert.That(testable.AddTcpClient(1000, 51001, signalRClientMock.Object, tcpChannelMock.Object), Is.Not.Null);
 
             Assert.That(await testable.RemoveTcpClient(1000, 50999), Is.False);
             Assert.That(testable.PublicMorozovTcpClients[1000].Keys, Is.EquivalentTo([51000, 51001]));
@@ -134,8 +136,8 @@ namespace TutoProxy.Client.Tests.Services {
         public async Task Stop_Test() {
             await testable.StartAsync(IPAddress.Any, Enumerable.Range(1000, 4).ToList(), Enumerable.Range(1, 65535).ToList());
 
-            Assert.That(testable.AddTcpClient(1000, 51000, signalRClientMock.Object), Is.Not.Null);
-            Assert.That(testable.AddTcpClient(1001, 51001, signalRClientMock.Object), Is.Not.Null);
+            Assert.That(testable.AddTcpClient(1000, 51000, signalRClientMock.Object, tcpChannelMock.Object), Is.Not.Null);
+            Assert.That(testable.AddTcpClient(1001, 51001, signalRClientMock.Object, tcpChannelMock.Object), Is.Not.Null);
 
             await testable.StopAsync();
 

--- a/Projects/TutoProxy/TutoProxy.Client.Tests/TutoProxy.Client.Tests.csproj
+++ b/Projects/TutoProxy/TutoProxy.Client.Tests/TutoProxy.Client.Tests.csproj
@@ -9,15 +9,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="NUnit.Analyzers" Version="4.7.0">
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="NUnit.Analyzers" Version="4.11.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
@@ -72,6 +72,7 @@ namespace TutoProxy.Server.CommandLine {
             public Task<int> InvokeAsync(InvocationContext context) {
                 Guard.NotNull(Server, nameof(Server));
                 Guard.NotNullOrEmpty(Sendto, nameof(Sendto));
+                Guard.NotNull(Id, nameof(Id));
                 Guard.NotNull(Tcp ?? Udp, $"Tcp ?? Udp");
 
                 var title = $"Connback proxy client TuTo [{Id}], {Server} >>>> {Sendto}";
@@ -114,7 +115,7 @@ namespace TutoProxy.Server.CommandLine {
                         while(!cancellationToken.IsCancellationRequested) {
                             try {
                                 logStatus("connection to server...");
-                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id, Protocol, Math.Clamp(Parallel, 1, 8), cancellationToken);
+                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id!, Protocol, Math.Clamp(Parallel, 1, 8), cancellationToken);
 
                                 logStatus($"{connectionId}");
                                 break;

--- a/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Net;
 using System.Reflection;
 using Microsoft.Extensions.Hosting;
@@ -12,70 +11,66 @@ using TuToProxy.Core.CommandLine;
 
 namespace TutoProxy.Server.CommandLine {
     public class AppRootCommand : RootCommand {
+        public Argument<string> ServerArg { get; }
+        public Argument<string> SendtoArg { get; }
+        public Argument<string> IdArg { get; }
+        public Option<PortsArgument?> TcpOption { get; }
+        public Option<PortsArgument?> UdpOption { get; }
+        public Option<TransportProtocol> ProtocolOption { get; }
+        public Option<int> ParallelOption { get; }
+        public Option<bool> DaemonOption { get; }
+
         public AppRootCommand() : base("Connback proxy client TuTo") {
-            Add(new Argument<string>("server", "Remote server address"));
-            Add(new Argument<string>("sendto", "Sendto IP address"));
-            Add(new Option<string>("--id", "Client ID"));
-            var tcpOption = PortsArgument.CreateOption("--tcp", $"Tunneling ports, format like '--tcp=80,81,443,8000-8100'");
-            var udpOption = PortsArgument.CreateOption("--udp", $"Tunneling ports, format like '--udp=700-900,65500'");
-            Add(tcpOption);
-            Add(udpOption);
-            Add(new Option<TransportProtocol>("--protocol", () => TransportProtocol.Auto, "Transport protocol: Auto, Http, WebSocket"));
-            Add(new Option<int>("--parallel", () => 1, "Number of parallel SignalR connections (1-8)"));
-            Add(new Option<bool>("--daemon", () => false, "Run as a daemon"));
-            AddValidator((result) => {
+            ServerArg = new Argument<string>("server") { Description = "Remote server address" };
+            SendtoArg = new Argument<string>("sendto") { Description = "Sendto IP address" };
+            IdArg = new Argument<string>("--id") { Description = "Client ID" };
+            TcpOption = PortsArgument.CreateOption("--tcp", $"Tunneling ports, format like '--tcp=80,81,443,8000-8100'");
+            UdpOption = PortsArgument.CreateOption("--udp", $"Tunneling ports, format like '--udp=700-900,65500'");
+            ProtocolOption = new Option<TransportProtocol>("--protocol") { Description = "Transport protocol: Auto, Http, WebSocket", DefaultValueFactory = _ => TransportProtocol.Auto };
+            ParallelOption = new Option<int>("--parallel") { Description = "Number of parallel SignalR connections (1-8)", DefaultValueFactory = _ => 1 };
+            DaemonOption = new Option<bool>("--daemon") { Description = "Run as a daemon", DefaultValueFactory = _ => false };
+
+            Add(ServerArg);
+            Add(SendtoArg);
+            Add(IdArg);
+            Add(TcpOption);
+            Add(UdpOption);
+            Add(ProtocolOption);
+            Add(ParallelOption);
+            Add(DaemonOption);
+
+            Validators.Add((result) => {
                 try {
-                    if(!result.Children.Any(x => x.GetValueForOption(tcpOption) != null || x.GetValueForOption(udpOption) != null)) {
-                        result.ErrorMessage = "tcp or udp options requried";
+                    if(!result.Children.Any(x => x.GetValue(TcpOption) != null || x.GetValue(UdpOption) != null)) {
+                        result.AddError("tcp or udp options requried");
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly ILogger logger;
-            readonly ISignalRClient signalrClient;
-            readonly IHostApplicationLifetime applicationLifetime;
-            readonly IClientsService clientsService;
-            readonly IProcessMonitor processMonitor;
+        public void ConfigureAction(
+            Serilog.ILogger logger,
+            ISignalRClient signalrClient,
+            IHostApplicationLifetime applicationLifetime,
+            IClientsService clientsService) {
+            SetAction((parseResult, cancellationToken) => {
+                var server = parseResult.GetValue(ServerArg);
+                var sendto = parseResult.GetValue(SendtoArg);
+                var id = parseResult.GetValue(IdArg);
+                var tcp = parseResult.GetValue(TcpOption);
+                var udp = parseResult.GetValue(UdpOption);
+                var protocol = parseResult.GetValue(ProtocolOption);
+                var parallel = parseResult.GetValue(ParallelOption);
+                var daemon = parseResult.GetValue(DaemonOption);
 
-            public string? Server { get; set; }
-            public string? Sendto { get; set; }
-            public string? Id { get; set; }
-            public PortsArgument? Udp { get; set; }
-            public PortsArgument? Tcp { get; set; }
-            public TransportProtocol Protocol { get; set; }
-            public int Parallel { get; set; }
-            public bool? Daemon { get; set; }
+                Guard.NotNull(server, nameof(server));
+                Guard.NotNullOrEmpty(sendto, nameof(sendto));
+                Guard.NotNull(id, nameof(id));
+                Guard.NotNull(tcp ?? udp, $"tcp ?? udp");
 
-            public Handler(
-                ILogger logger,
-                ISignalRClient signalrClient,
-                IHostApplicationLifetime applicationLifetime,
-                IClientsService clientsService,
-                IProcessMonitor processMonitor
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(signalrClient, nameof(signalrClient));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                Guard.NotNull(clientsService, nameof(clientsService));
-                Guard.NotNull(processMonitor, nameof(processMonitor));
-                this.logger = logger;
-                this.signalrClient = signalrClient;
-                this.applicationLifetime = applicationLifetime;
-                this.clientsService = clientsService;
-                this.processMonitor = processMonitor;
-            }
-
-            public Task<int> InvokeAsync(InvocationContext context) {
-                Guard.NotNull(Server, nameof(Server));
-                Guard.NotNullOrEmpty(Sendto, nameof(Sendto));
-                Guard.NotNull(Id, nameof(Id));
-                Guard.NotNull(Tcp ?? Udp, $"Tcp ?? Udp");
-
-                var title = $"Connback proxy client TuTo [{Id}], {Server} >>>> {Sendto}";
+                var title = $"Connback proxy client TuTo [{id}], {server} >>>> {sendto}";
                 var version = $"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}";
                 logger.Information(version);
                 logger.Information(title);
@@ -85,18 +80,18 @@ namespace TutoProxy.Server.CommandLine {
                     await clientsService.StopAsync();
                 });
 
-                if(Daemon != null && Daemon.Value) {
+                if(daemon) {
                     Program.ConsoleLevelSwitch.MinimumLevel = Serilog.Events.LogEventLevel.Warning;
                     TcpSocketParams.TrafficMonitoring = false;
                     UdpSocketParams.TrafficMonitoring = false;
-                    _ = StartServices(appStoppingReg.Token, (status) => logger.Information($"server: {status}"));
+                    _ = StartServices(server!, sendto!, id!, tcp, udp, protocol, parallel, logger, signalrClient, clientsService, appStoppingReg.Token, (status) => logger.Information($"server: {status}"));
                     _ = appStoppingReg.Token.WaitHandle.WaitOne();
                 } else {
                     Application.IsMouseDisabled = true;
                     Application.Init();
-                    var mainWindow = new MainWindow(title, Tcp?.Ports, Udp?.Ports);
+                    var mainWindow = new MainWindow(title, tcp?.Ports, udp?.Ports);
                     mainWindow.Ready += () => {
-                        _ = StartServices(appStoppingReg.Token, (status) => Application.MainLoop.Invoke(() => { mainWindow.Title = $"{title} - {status}"; }));
+                        _ = StartServices(server!, sendto!, id!, tcp, udp, protocol, parallel, logger, signalrClient, clientsService, appStoppingReg.Token, (status) => Application.MainLoop.Invoke(() => { mainWindow.Title = $"{title} - {status}"; }));
                     };
 
                     Application.Top.Add(new MainMenu(version), mainWindow);
@@ -106,31 +101,39 @@ namespace TutoProxy.Server.CommandLine {
                 }
 
                 return Task.FromResult(0);
-            }
+            });
+        }
 
-            async Task StartServices(CancellationToken cancellationToken, Action<string> logStatus) {
-                try {
-                    await clientsService.StartAsync(IPAddress.Parse(Sendto!), Tcp?.Ports, Udp?.Ports);
-                    _ = Task.Run(async () => {
-                        while(!cancellationToken.IsCancellationRequested) {
-                            try {
-                                logStatus("connection to server...");
-                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id!, Protocol, Math.Clamp(Parallel, 1, 8), cancellationToken);
+        static async Task StartServices(
+            string server, string sendto, string id,
+            PortsArgument? tcp, PortsArgument? udp,
+            TransportProtocol protocol, int parallel,
+            Serilog.ILogger logger,
+            ISignalRClient signalrClient,
+            IClientsService clientsService,
+            CancellationToken cancellationToken,
+            Action<string> logStatus) {
+            try {
+                await clientsService.StartAsync(IPAddress.Parse(sendto), tcp?.Ports, udp?.Ports);
+                _ = Task.Run(async () => {
+                    while(!cancellationToken.IsCancellationRequested) {
+                        try {
+                            logStatus("connection to server...");
+                            var connectionId = await signalrClient.StartAsync(server, tcp?.Argument, udp?.Argument, id, protocol, Math.Clamp(parallel, 1, 8), cancellationToken);
 
-                                logStatus($"{connectionId}");
-                                break;
-                            } catch(HttpRequestException) {
-                                logger.Error("Connection failed");
-                                logStatus("connection failed. Retry...");
-                                await Task.Delay(5000, cancellationToken);
-                                logger.Information("Retry connect");
-                                continue;
-                            }
+                            logStatus($"{connectionId}");
+                            break;
+                        } catch(HttpRequestException) {
+                            logger.Error("Connection failed");
+                            logStatus("connection failed. Retry...");
+                            await Task.Delay(5000, cancellationToken);
+                            logger.Information("Retry connect");
+                            continue;
                         }
-                    }, cancellationToken);
-                } catch(Exception ex) {
-                    logger.Error($"StartServices error: {ex.Message}");
-                }
+                    }
+                }, cancellationToken);
+            } catch(Exception ex) {
+                logger.Error($"StartServices error: {ex.Message}");
             }
         }
     }

--- a/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
@@ -13,7 +13,7 @@ namespace TutoProxy.Server.CommandLine {
     public class AppRootCommand : RootCommand {
         public Argument<string> ServerArg { get; }
         public Argument<string> SendtoArg { get; }
-        public Argument<string> IdArg { get; }
+        public Option<string> IdArg { get; }
         public Option<PortsArgument?> TcpOption { get; }
         public Option<PortsArgument?> UdpOption { get; }
         public Option<TransportProtocol> ProtocolOption { get; }
@@ -23,7 +23,7 @@ namespace TutoProxy.Server.CommandLine {
         public AppRootCommand() : base("Connback proxy client TuTo") {
             ServerArg = new Argument<string>("server") { Description = "Remote server address" };
             SendtoArg = new Argument<string>("sendto") { Description = "Sendto IP address" };
-            IdArg = new Argument<string>("--id") { Description = "Client ID" };
+            IdArg = new Option<string>("--id") { Description = "Client ID" };
             TcpOption = PortsArgument.CreateOption("--tcp", $"Tunneling ports, format like '--tcp=80,81,443,8000-8100'");
             UdpOption = PortsArgument.CreateOption("--udp", $"Tunneling ports, format like '--udp=700-900,65500'");
             ProtocolOption = new Option<TransportProtocol>("--protocol") { Description = "Transport protocol: Auto, Http, WebSocket", DefaultValueFactory = _ => TransportProtocol.Auto };
@@ -67,7 +67,6 @@ namespace TutoProxy.Server.CommandLine {
 
                 Guard.NotNull(server, nameof(server));
                 Guard.NotNullOrEmpty(sendto, nameof(sendto));
-                Guard.NotNull(id, nameof(id));
                 Guard.NotNull(tcp ?? udp, $"tcp ?? udp");
 
                 var title = $"Connback proxy client TuTo [{id}], {server} >>>> {sendto}";
@@ -84,7 +83,7 @@ namespace TutoProxy.Server.CommandLine {
                     Program.ConsoleLevelSwitch.MinimumLevel = Serilog.Events.LogEventLevel.Warning;
                     TcpSocketParams.TrafficMonitoring = false;
                     UdpSocketParams.TrafficMonitoring = false;
-                    _ = StartServices(server!, sendto!, id!, tcp, udp, protocol, parallel, logger, signalrClient, clientsService, appStoppingReg.Token, (status) => logger.Information($"server: {status}"));
+                    _ = StartServices(server!, sendto!, id, tcp, udp, protocol, parallel, logger, signalrClient, clientsService, appStoppingReg.Token, (status) => logger.Information($"server: {status}"));
                     _ = appStoppingReg.Token.WaitHandle.WaitOne();
                 } else {
                     Application.IsMouseDisabled = true;
@@ -105,7 +104,7 @@ namespace TutoProxy.Server.CommandLine {
         }
 
         static async Task StartServices(
-            string server, string sendto, string id,
+            string server, string sendto, string? id,
             PortsArgument? tcp, PortsArgument? udp,
             TransportProtocol protocol, int parallel,
             Serilog.ILogger logger,

--- a/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/CommandLine/AppRootCommand.cs
@@ -21,6 +21,7 @@ namespace TutoProxy.Server.CommandLine {
             Add(tcpOption);
             Add(udpOption);
             Add(new Option<TransportProtocol>("--protocol", () => TransportProtocol.Auto, "Transport protocol: Auto, Http, WebSocket"));
+            Add(new Option<int>("--parallel", () => 1, "Number of parallel SignalR connections (1-8)"));
             Add(new Option<bool>("--daemon", () => false, "Run as a daemon"));
             AddValidator((result) => {
                 try {
@@ -46,6 +47,7 @@ namespace TutoProxy.Server.CommandLine {
             public PortsArgument? Udp { get; set; }
             public PortsArgument? Tcp { get; set; }
             public TransportProtocol Protocol { get; set; }
+            public int Parallel { get; set; }
             public bool? Daemon { get; set; }
 
             public Handler(
@@ -112,7 +114,7 @@ namespace TutoProxy.Server.CommandLine {
                         while(!cancellationToken.IsCancellationRequested) {
                             try {
                                 logStatus("connection to server...");
-                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id, Protocol, cancellationToken);
+                                var connectionId = await signalrClient.StartAsync(Server!, Tcp?.Argument, Udp?.Argument, Id, Protocol, Math.Clamp(Parallel, 1, 8), cancellationToken);
 
                                 logStatus($"{connectionId}");
                                 break;

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/ClientFactory.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/ClientFactory.cs
@@ -3,7 +3,7 @@ using TutoProxy.Client.Services;
 
 namespace TutoProxy.Client.Communication {
     public interface IClientFactory {
-        TcpClient CreateTcp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, IProcessMonitor processMonitor);
+        TcpClient CreateTcp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, ITcpDataChannel tcpChannel, IProcessMonitor processMonitor);
         UdpClient CreateUdp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, IProcessMonitor processMonitor);
     }
     public class ClientFactory : IClientFactory {
@@ -14,8 +14,8 @@ namespace TutoProxy.Client.Communication {
             this.logger = logger;
         }
 
-        public TcpClient CreateTcp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, IProcessMonitor processMonitor) {
-            return new TcpClient(new IPEndPoint(localIpAddress, port), originPort, logger, clientsService, dataTunnelClient, processMonitor);
+        public TcpClient CreateTcp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, ITcpDataChannel tcpChannel, IProcessMonitor processMonitor) {
+            return new TcpClient(new IPEndPoint(localIpAddress, port), originPort, logger, clientsService, dataTunnelClient, tcpChannel, processMonitor);
         }
 
         public UdpClient CreateUdp(IPAddress localIpAddress, int port, int originPort, IClientsService clientsService, ISignalRClient dataTunnelClient, IProcessMonitor processMonitor) {

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/ITcpDataChannel.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/ITcpDataChannel.cs
@@ -1,0 +1,8 @@
+﻿using TuToProxy.Core.Models;
+
+namespace TutoProxy.Client.Communication {
+    public interface ITcpDataChannel {
+        Task<int> SendTcpResponse(TcpDataResponseModel response, CancellationToken cancellationToken);
+        Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken);
+    }
+}

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -12,7 +12,7 @@ using TypedSignalR.Client;
 
 namespace TutoProxy.Client.Communication {
     public interface ISignalRClient : IDisposable {
-        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken);
+        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken);
         Task StopAsync();
         Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken);
         Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken);
@@ -178,7 +178,7 @@ namespace TutoProxy.Client.Communication {
         public void Dispose() {
         }
 
-        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken) {
+        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken) {
             Guard.NotNullOrEmpty(server, nameof(server));
             Guard.NotNull(tcpQuery ?? udpQuery, $"Tcp ?? Udp");
 
@@ -193,7 +193,7 @@ namespace TutoProxy.Client.Communication {
                 var query = QueryString.Create(new[] {
                     KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery ?? ""),
                     KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery ?? ""),
-                    KeyValuePair.Create(SignalRParams.ClientId, clientId),
+                    KeyValuePair.Create(SignalRParams.ClientId, clientId ?? ""),
                     KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
                     KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
                 });

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -12,7 +12,7 @@ using TypedSignalR.Client;
 
 namespace TutoProxy.Client.Communication {
     public interface ISignalRClient : IDisposable {
-        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken);
+        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken);
         Task StopAsync();
         Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken);
         Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken);
@@ -178,7 +178,7 @@ namespace TutoProxy.Client.Communication {
         public void Dispose() {
         }
 
-        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken) {
+        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken) {
             Guard.NotNullOrEmpty(server, nameof(server));
             Guard.NotNull(tcpQuery ?? udpQuery, $"Tcp ?? Udp");
 
@@ -193,7 +193,7 @@ namespace TutoProxy.Client.Communication {
                 var query = QueryString.Create(new[] {
                     KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery ?? ""),
                     KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery ?? ""),
-                    KeyValuePair.Create(SignalRParams.ClientId, clientId ?? ""),
+                    KeyValuePair.Create(SignalRParams.ClientId, clientId),
                     KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
                     KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
                 });

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -67,14 +67,14 @@ namespace TutoProxy.Client.Communication {
             }
 
             public Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
-                logger.Debug($"HandleDisconnectUdp :{socketAddress}, {totalTransfered}");
+                logger.Debug("HandleDisconnectUdp :{socketAddress}, {totalTransfered}", socketAddress, totalTransfered);
                 var client = clientsService.ObtainUdpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient);
                 client.Disconnect(totalTransfered);
                 return Task.CompletedTask;
             }
 
             public async Task<SocketError> ConnectTcp(SocketAddressModel socketAddress) {
-                logger.Debug($"HandleConnectTcp :{socketAddress}");
+                logger.Debug("HandleConnectTcp :{socketAddress}", socketAddress);
                 var client = clientsService.AddTcpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient);
                 var result = await client.Connect(cancellationToken);
                 if(result != SocketError.Success) {

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -191,9 +191,9 @@ namespace TutoProxy.Client.Communication {
 
             for(int i = 0; i < parallelCount; i++) {
                 var query = QueryString.Create(new[] {
-                    KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery),
-                    KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery),
-                    KeyValuePair.Create(SignalRParams.ClientId, clientId),
+                    KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery ?? ""),
+                    KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery ?? ""),
+                    KeyValuePair.Create(SignalRParams.ClientId, clientId ?? ""),
                     KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
                     KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
                 });

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -189,14 +189,23 @@ namespace TutoProxy.Client.Communication {
 
             string? firstConnectionId = null;
 
+            var queryParams = new List<KeyValuePair<string, string>>();
+            if (!string.IsNullOrEmpty(tcpQuery)) {
+                queryParams.Add(KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery));
+            }
+            if (!string.IsNullOrEmpty(udpQuery)) {
+                queryParams.Add(KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery));
+            }
+            if (!string.IsNullOrEmpty(clientId)) {
+                queryParams.Add(KeyValuePair.Create(SignalRParams.ClientId, clientId));
+            }
+
             for(int i = 0; i < parallelCount; i++) {
-                var query = QueryString.Create(new[] {
-                    KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery ?? ""),
-                    KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery ?? ""),
-                    KeyValuePair.Create(SignalRParams.ClientId, clientId ?? ""),
+                var query = QueryString.Create(queryParams.Concat([
                     KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
                     KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
-                });
+                ]));
+
                 ub.Query = query.ToString();
 
                 var hubConnection = new HubConnectionBuilder()

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/SignalRClient.cs
@@ -1,5 +1,4 @@
-﻿using System.CommandLine;
-using System.Net.Sockets;
+﻿using System.Net.Sockets;
 using MessagePack;
 using MessagePack.Resolvers;
 using Microsoft.AspNetCore.Http;
@@ -13,7 +12,7 @@ using TypedSignalR.Client;
 
 namespace TutoProxy.Client.Communication {
     public interface ISignalRClient : IDisposable {
-        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, CancellationToken cancellationToken);
+        Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken);
         Task StopAsync();
         Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken);
         Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken);
@@ -37,18 +36,81 @@ namespace TutoProxy.Client.Communication {
             }
         }
 
+        class SignalRConnection : ITcpDataChannel, IAsyncDisposable {
+            readonly HubConnection connection;
+            readonly IServerHub hubProxy;
+            readonly IDisposable receiverSubscription;
+
+            public int Index { get; }
+
+            public SignalRConnection(int index, HubConnection connection, IClientReceiver receiver) {
+                Index = index;
+                this.connection = connection;
+                hubProxy = connection.CreateHubProxy<IServerHub>();
+                receiverSubscription = connection.Register<IClientReceiver>(receiver);
+            }
+
+            public async ValueTask DisposeAsync() {
+                receiverSubscription.Dispose();
+                await connection.DisposeAsync();
+            }
+
+            public Task<int> SendTcpResponse(TcpDataResponseModel response, CancellationToken cancellationToken) {
+                if(connection.State == HubConnectionState.Connected) {
+                    return hubProxy.TcpResponse(response);
+                }
+                return Task.FromResult(-1);
+            }
+
+            public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
+                if(connection.State == HubConnectionState.Connected) {
+                    return hubProxy.DisconnectTcp(socketAddress);
+                }
+                return Task.FromResult(false);
+            }
+
+            public Task SendUdpResponse(UdpDataResponseModel response) {
+                if(connection.State == HubConnectionState.Connected) {
+                    return hubProxy.UdpResponse(response);
+                }
+                return Task.CompletedTask;
+            }
+
+            public Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
+                if(connection.State == HubConnectionState.Connected) {
+                    return hubProxy.DisconnectUdp(socketAddress, totalTransfered);
+                }
+                return Task.CompletedTask;
+            }
+        }
+
+        // Wrapper that allows setting the actual channel after construction
+        class TcpChannelWrapper : ITcpDataChannel {
+            public ITcpDataChannel? Channel { get; set; }
+
+            public Task<int> SendTcpResponse(TcpDataResponseModel response, CancellationToken cancellationToken) {
+                return Channel?.SendTcpResponse(response, cancellationToken) ?? Task.FromResult(-1);
+            }
+
+            public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
+                return Channel?.DisconnectTcp(socketAddress, cancellationToken) ?? Task.FromResult(false);
+            }
+        }
+
         class ClientReceiver : IClientReceiver {
             readonly ILogger logger;
             readonly IClientsService clientsService;
             readonly ISignalRClient signalRClient;
+            readonly ITcpDataChannel tcpChannel;
             readonly Func<Task> stopAsync;
             readonly CancellationToken cancellationToken;
 
             public ClientReceiver(ILogger logger, IClientsService clientsService, ISignalRClient signalRClient,
-                    Func<Task> stopAsync, CancellationToken cancellationToken) {
+                    ITcpDataChannel tcpChannel, Func<Task> stopAsync, CancellationToken cancellationToken) {
                 this.logger = logger;
                 this.clientsService = clientsService;
                 this.signalRClient = signalRClient;
+                this.tcpChannel = tcpChannel;
                 this.stopAsync = stopAsync;
                 this.cancellationToken = cancellationToken;
             }
@@ -75,7 +137,7 @@ namespace TutoProxy.Client.Communication {
 
             public async Task<SocketError> ConnectTcp(SocketAddressModel socketAddress) {
                 logger.Debug("HandleConnectTcp :{socketAddress}", socketAddress);
-                var client = clientsService.AddTcpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient);
+                var client = clientsService.AddTcpClient(socketAddress.Port, socketAddress.OriginPort, signalRClient, tcpChannel);
                 var result = await client.Connect(cancellationToken);
                 if(result != SocketError.Success) {
                     await client.DisconnectAsync();
@@ -101,9 +163,8 @@ namespace TutoProxy.Client.Communication {
 
         readonly ILogger logger;
         readonly IClientsService clientsService;
-        HubConnection? connection = null;
-        IServerHub? hubProxy = null;
-        IDisposable? receiverSubscription = null;
+        readonly List<SignalRConnection> connections = new();
+        int udpConnectionIndex = 0;
 
         public SignalRClient(
                 ILogger logger,
@@ -117,7 +178,7 @@ namespace TutoProxy.Client.Communication {
         public void Dispose() {
         }
 
-        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, CancellationToken cancellationToken) {
+        public async Task<string> StartAsync(string server, string? tcpQuery, string? udpQuery, string? clientId, TransportProtocol protocol, int parallelCount, CancellationToken cancellationToken) {
             Guard.NotNullOrEmpty(server, nameof(server));
             Guard.NotNull(tcpQuery ?? udpQuery, $"Tcp ?? Udp");
 
@@ -126,82 +187,104 @@ namespace TutoProxy.Client.Communication {
             var ub = new UriBuilder(server);
             ub.Path = SignalRParams.Path;
 
-            var query = QueryString.Create(new[] {
-                KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery),
-                KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery),
-                KeyValuePair.Create(SignalRParams.ClientId, clientId)
-            });
-            ub.Query = query.ToString();
+            string? firstConnectionId = null;
 
-            connection = new HubConnectionBuilder()
-                 .WithUrl(ub.Uri, options => {
-                     if(protocol == TransportProtocol.WebSocket) {
-                         options.Transports = HttpTransportType.WebSockets;
-                         options.SkipNegotiation = true;
-                     } else if(protocol == TransportProtocol.Http) {
-                         options.Transports = HttpTransportType.LongPolling;
-                     }
-                 })
-                 .WithAutomaticReconnect(new RetryPolicy(logger))
-                 .AddMessagePackProtocol(config => {
-                     config.SerializerOptions = MessagePackSerializerOptions.Standard
-                            .WithResolver(StandardResolver.Instance)
-                            .WithSecurity(MessagePackSecurity.UntrustedData);
-                 })
-                 .Build();
+            for(int i = 0; i < parallelCount; i++) {
+                var query = QueryString.Create(new[] {
+                    KeyValuePair.Create(SignalRParams.TcpQuery, tcpQuery),
+                    KeyValuePair.Create(SignalRParams.UdpQuery, udpQuery),
+                    KeyValuePair.Create(SignalRParams.ClientId, clientId),
+                    KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
+                    KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
+                });
+                ub.Query = query.ToString();
 
-            hubProxy = connection.CreateHubProxy<IServerHub>();
-            var receiver = new ClientReceiver(logger, clientsService, this, StopAsync, cancellationToken);
-            receiverSubscription = connection.Register<IClientReceiver>(receiver);
+                var hubConnection = new HubConnectionBuilder()
+                     .WithUrl(ub.Uri, options => {
+                         if(protocol == TransportProtocol.WebSocket) {
+                             options.Transports = HttpTransportType.WebSockets;
+                             options.SkipNegotiation = true;
+                         } else if(protocol == TransportProtocol.Http) {
+                             options.Transports = HttpTransportType.LongPolling;
+                         }
+                     })
+                     .WithAutomaticReconnect(new RetryPolicy(logger))
+                     .AddMessagePackProtocol(config => {
+                         config.SerializerOptions = MessagePackSerializerOptions.Standard
+                                .WithResolver(StandardResolver.Instance)
+                                .WithSecurity(MessagePackSecurity.UntrustedData);
+                     })
+                     .Build();
 
-            connection.Reconnecting += e => {
-                logger.Warning($"Connection lost. Reconnecting");
-                return Task.CompletedTask;
-            };
+                // Use wrapper to break circular dependency
+                var channelWrapper = new TcpChannelWrapper();
+                var receiver = new ClientReceiver(logger, clientsService, this, channelWrapper, StopAsync, cancellationToken);
+                var signalRConn = new SignalRConnection(i, hubConnection, receiver);
+                channelWrapper.Channel = signalRConn;
+                connections.Add(signalRConn);
 
-            connection.Reconnected += s => {
-                logger.Information($"Connection reconnected: {s}");
-                return Task.CompletedTask;
-            };
+                var connIndex = i;
+                hubConnection.Reconnecting += e => {
+                    logger.Warning($"Connection[{connIndex}] lost. Reconnecting");
+                    return Task.CompletedTask;
+                };
 
-            await connection.StartAsync(cancellationToken);
-            logger.Information("Connection started");
-            return connection.ConnectionId ?? "????";
+                hubConnection.Reconnected += s => {
+                    logger.Information($"Connection[{connIndex}] reconnected: {s}");
+                    return Task.CompletedTask;
+                };
+
+                await hubConnection.StartAsync(cancellationToken);
+                logger.Information($"Connection[{i}] started: {hubConnection.ConnectionId}");
+
+                if(i == 0) {
+                    firstConnectionId = hubConnection.ConnectionId;
+                }
+            }
+
+            logger.Information($"All {parallelCount} connections started");
+            return firstConnectionId ?? "????";
         }
 
         public async Task StopAsync() {
-            receiverSubscription?.Dispose();
-            receiverSubscription = null;
-            hubProxy = null;
-            if(connection != null) {
-                await connection.DisposeAsync();
-                logger.Information("Connection stopped");
-                connection = null;
+            if(connections.Count == 0) {
+                return;
             }
+            foreach(var conn in connections) {
+                await conn.DisposeAsync();
+            }
+            connections.Clear();
+            logger.Information("All connections stopped");
         }
 
         public async Task SendUdpResponse(UdpDataResponseModel response, CancellationToken cancellationToken) {
-            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
-                await hubProxy.UdpResponse(response);
+            if(connections.Count > 0) {
+                var index = Interlocked.Increment(ref udpConnectionIndex) % connections.Count;
+                await connections[index].SendUdpResponse(response);
             }
         }
 
         public async Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered, CancellationToken cancellationToken) {
-            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
-                await hubProxy.DisconnectUdp(socketAddress, totalTransfered);
+            if(connections.Count > 0) {
+                // Use first connection for UDP disconnect (it's a control message)
+                await connections[0].DisconnectUdp(socketAddress, totalTransfered);
             }
         }
 
         public Task<int> SendTcpResponse(TcpDataResponseModel response, CancellationToken cancellationToken) {
-            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
-                return hubProxy.TcpResponse(response);
+            // This method is kept for interface compatibility but should not be used for TCP
+            // TCP responses go through ITcpDataChannel (SignalRConnection) directly
+            if(connections.Count > 0) {
+                return connections[0].SendTcpResponse(response, cancellationToken);
             }
             return Task.FromResult(-1);
         }
 
         public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
-            if(hubProxy != null && connection?.State == HubConnectionState.Connected) {
-                return hubProxy.DisconnectTcp(socketAddress);
+            // This method is kept for interface compatibility but should not be used for TCP
+            // TCP disconnects go through ITcpDataChannel (SignalRConnection) directly
+            if(connections.Count > 0) {
+                return connections[0].DisconnectTcp(socketAddress, cancellationToken);
             }
             return Task.FromResult(false);
         }

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/TcpClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/TcpClient.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using TutoProxy.Client.Services;
 using TuToProxy.Core;
 using TuToProxy.Core.Extensions;
+using TuToProxy.Core.Pooling;
 
 namespace TutoProxy.Client.Communication {
 
@@ -86,8 +87,16 @@ namespace TutoProxy.Client.Communication {
                     totalReceived += receivedBytes;
                     var data = receiveBuffer[..receivedBytes];
 
-                    var response = new TcpDataResponseModel() { Port = Port, OriginPort = OriginPort, Data = data };
-                    var transmitted = await dataTunnelClient.SendTcpResponse(response, cancellationToken);
+                    var response = DataModelPool<TcpDataResponseModel>.Rent();
+                    response.Port = Port;
+                    response.OriginPort = OriginPort;
+                    response.Data = data;
+                    int transmitted;
+                    try {
+                        transmitted = await dataTunnelClient.SendTcpResponse(response, cancellationToken);
+                    } finally {
+                        DataModelPool<TcpDataResponseModel>.Return(response);
+                    }
                     if(receivedBytes != transmitted) {
                         logger.Error($"{this} response transmit error ({transmitted})");
                         throw new SocketException((int)SocketError.ConnectionAborted);

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/TcpClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/TcpClient.cs
@@ -13,13 +13,15 @@ namespace TutoProxy.Client.Communication {
         long requestLogTicks = Environment.TickCount64;
         long responseLogTicks = Environment.TickCount64;
         readonly Socket socket;
+        readonly ITcpDataChannel tcpChannel;
 
         Int64 totalTransmitted;
         Int64 totalReceived;
 
-        public TcpClient(IPEndPoint serverEndPoint, int originPort, ILogger logger, IClientsService clientsService, ISignalRClient dataTunnelClient, IProcessMonitor processMonitor)
+        public TcpClient(IPEndPoint serverEndPoint, int originPort, ILogger logger, IClientsService clientsService, ISignalRClient dataTunnelClient, ITcpDataChannel tcpChannel, IProcessMonitor processMonitor)
             : base(serverEndPoint, originPort, logger, clientsService, dataTunnelClient, processMonitor) {
 
+            this.tcpChannel = tcpChannel;
             socket = new Socket(serverEndPoint.AddressFamily, SocketType.Stream, ProtocolType.Tcp);
             socket.NoDelay = true;
             socket.ReceiveBufferSize = TcpSocketParams.ReceiveBufferSize;
@@ -93,7 +95,7 @@ namespace TutoProxy.Client.Communication {
                     response.Data = data;
                     int transmitted;
                     try {
-                        transmitted = await dataTunnelClient.SendTcpResponse(response, cancellationToken);
+                        transmitted = await tcpChannel.SendTcpResponse(response, cancellationToken);
                     } finally {
                         DataModelPool<TcpDataResponseModel>.Return(response);
                     }
@@ -117,7 +119,7 @@ namespace TutoProxy.Client.Communication {
             }
             if(!cancellationTokenSource.IsCancellationRequested) {
                 try {
-                    if(!await dataTunnelClient.DisconnectTcp(new SocketAddressModel() { Port = Port, OriginPort = OriginPort }, cancellationToken)) {
+                    if(!await tcpChannel.DisconnectTcp(new SocketAddressModel() { Port = Port, OriginPort = OriginPort }, cancellationToken)) {
                         logger.Error($"{this} disconnect command error");
                     }
                 } catch(Exception) { }

--- a/Projects/TutoProxy/TutoProxy.Client/Communication/UdpClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Communication/UdpClient.cs
@@ -4,6 +4,7 @@ using TutoProxy.Client.Services;
 using TuToProxy.Core;
 using TuToProxy.Core.Exceptions;
 using TuToProxy.Core.Extensions;
+using TuToProxy.Core.Pooling;
 
 namespace TutoProxy.Client.Communication {
     public class UdpClient : BaseClient {
@@ -68,8 +69,15 @@ namespace TutoProxy.Client.Communication {
                             break;
                         }
                         totalReceived += result.Buffer.Length;
-                        var response = new UdpDataResponseModel() { Port = request.Port, OriginPort = request.OriginPort, Data = result.Buffer };
-                        await dataTunnelClient.SendUdpResponse(response, cancellationToken);
+                        var response = DataModelPool<UdpDataResponseModel>.Rent();
+                        response.Port = request.Port;
+                        response.OriginPort = request.OriginPort;
+                        response.Data = result.Buffer;
+                        try {
+                            await dataTunnelClient.SendUdpResponse(response, cancellationToken);
+                        } finally {
+                            DataModelPool<UdpDataResponseModel>.Return(response);
+                        }
 
                         if(UdpSocketParams.TrafficMonitoring && Environment.TickCount64 - responseLogTicks >= UdpSocketParams.LogUpdatePeriod * 1000) {
                             responseLogTicks = Environment.TickCount64;

--- a/Projects/TutoProxy/TutoProxy.Client/Program.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Program.cs
@@ -1,8 +1,4 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
-using Microsoft.Extensions.DependencyInjection;
+﻿using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Serilog.Core;
 using Serilog.Events;
@@ -16,27 +12,38 @@ class Program {
         = new LoggingLevelSwitch(LogEventLevel.Fatal);
 
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}", levelSwitch: ConsoleLevelSwitch)
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day,
-                             restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Warning)
-                )
-                .UseServiceProviderFactory(context => {
-                    var factory = ServiceProviderFactory.Instance;
-                    return ServiceProviderFactory.Instance;
-                })
-                .ConfigureServices((_, services) => {
-                    services.AddSingleton<ISignalRClient, SignalRClient>();
-                    services.AddSingleton<IClientsService, ClientsService>();
-                    services.AddSingleton<IClientFactory, ClientFactory>();
-                    services.AddSingleton<IProcessMonitor, ProcessMonitor>();
-                })
+        using var host = Host.CreateDefaultBuilder(args)
+            .UseSerilog((_, config) => config
+                .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}", levelSwitch: ConsoleLevelSwitch)
+                .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day,
+                         restrictedToMinimumLevel: LogEventLevel.Warning)
             )
-            .UseDefaults()
+            .UseServiceProviderFactory(context => {
+                var factory = ServiceProviderFactory.Instance;
+                return ServiceProviderFactory.Instance;
+            })
+            .ConfigureServices((_, services) => {
+                services.AddSingleton<ISignalRClient, SignalRClient>();
+                services.AddSingleton<IClientsService, ClientsService>();
+                services.AddSingleton<IClientFactory, ClientFactory>();
+                services.AddSingleton<IProcessMonitor, ProcessMonitor>();
+            })
             .Build();
-        return await runner.InvokeAsync(args);
+
+        await host.StartAsync();
+
+        var logger = host.Services.GetRequiredService<Serilog.ILogger>();
+        var signalrClient = host.Services.GetRequiredService<ISignalRClient>();
+        var applicationLifetime = host.Services.GetRequiredService<IHostApplicationLifetime>();
+        var clientsService = host.Services.GetRequiredService<IClientsService>();
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger, signalrClient, applicationLifetime, clientsService);
+
+        var parseResult = command.Parse(args);
+        var result = await parseResult.InvokeAsync();
+
+        await host.StopAsync();
+        return result;
     }
 }

--- a/Projects/TutoProxy/TutoProxy.Client/Properties/launchSettings.json
+++ b/Projects/TutoProxy/TutoProxy.Client/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "TutoProxy.Client": {
       "commandName": "Project",
-      "commandLineArgs": "http://127.0.0.1:8088 192.168.244.139 --tcp=8001 --id=ClientSec --daemon",
+      "commandLineArgs": "http://172.31.182.199:8088 127.0.0.1 --tcp=5201 --udp=5201 --id=ClientSec --parallel=1",
       "hotReloadEnabled": false
     }
   }

--- a/Projects/TutoProxy/TutoProxy.Client/Services/ClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Client/Services/ClientsService.cs
@@ -8,7 +8,7 @@ using TuToProxy.Core.Exceptions;
 namespace TutoProxy.Client.Services {
     public interface IClientsService {
         Task StartAsync(IPAddress localIpAddress, List<int>? tcpPorts, List<int>? udpPorts);
-        TcpClient AddTcpClient(int port, int originPort, ISignalRClient dataTunnelClient);
+        TcpClient AddTcpClient(int port, int originPort, ISignalRClient dataTunnelClient, ITcpDataChannel tcpChannel);
         bool ObtainTcpClient(int port, int originPort, out TcpClient? client);
         ValueTask<bool> RemoveTcpClient(int port, int originPort);
 
@@ -50,7 +50,7 @@ namespace TutoProxy.Client.Services {
             this.udpPorts = udpPorts;
         }
 
-        public TcpClient AddTcpClient(int port, int originPort, ISignalRClient dataTunnelClient) {
+        public TcpClient AddTcpClient(int port, int originPort, ISignalRClient dataTunnelClient, ITcpDataChannel tcpChannel) {
             var commonPortClients = tcpClients.GetOrAdd(port,
                     _ => {
                         if(tcpPorts == null || !tcpPorts.Contains(port)) {
@@ -64,7 +64,7 @@ namespace TutoProxy.Client.Services {
             var client = commonPortClients.GetOrAdd(originPort,
                 _ => {
                     Debug.WriteLine($"ObtainClient: add tcp for OriginPort {originPort}, {tcpClients.Count}, {commonPortClients.Count}");
-                    return clientFactory.CreateTcp(localIpAddress, port, originPort, this, dataTunnelClient, processMonitor);
+                    return clientFactory.CreateTcp(localIpAddress, port, originPort, this, dataTunnelClient, tcpChannel, processMonitor);
                 }
             );
             return client;

--- a/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
+++ b/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
@@ -9,10 +9,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.0" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.4" />
-    <PackageReference Include="Terminal.Gui" Version="1.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Http.Extensions" Version="2.3.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.3" />
+    <PackageReference Include="Terminal.Gui" Version="1.19.0" />
     <PackageReference Include="TypedSignalR.Client" Version="3.6.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>

--- a/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
+++ b/Projects/TutoProxy/TutoProxy.Client/TutoProxy.Client.csproj
@@ -5,7 +5,7 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.4</Version>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs
@@ -31,14 +31,6 @@ namespace TutoProxy.Server.Tests.Services {
             public ConcurrentDictionary<string, HubClient> PublicMorozovConnectedClients {
                 get { return connectedClients; }
             }
-
-            public ConcurrentDictionary<int, string> PublicTcpPortToConnectionId {
-                get { return tcpPortToConnectionId; }
-            }
-
-            public ConcurrentDictionary<int, string> PublicUdpPortToConnectionId {
-                get { return udpPortToConnectionId; }
-            }
         }
 
 
@@ -142,13 +134,10 @@ namespace TutoProxy.Server.Tests.Services {
         [Test]
         public async Task GetClient_Test() {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
-                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
+                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1, 65535), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
-
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId1", new HubClient(localEndPoint, 
-                            Enumerable.Range(2000, 1).ToList(), Enumerable.Range(2000, 1), serviceProviderMock.Object));
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
+            await testable.Connect("connectionId1", "tcpquery=2000&udpquery=2000");
 
             Assert.That(testable.GetClient("connectionId0")?.TcpPorts, Has.Member(1000));
             Assert.That(testable.GetClient("connectionId1")?.TcpPorts, Has.Member(2000));
@@ -161,8 +150,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
 
             Assert.Throws<HubClientNotFoundException>(() => testable.GetClient("connectionId19"));
         }
@@ -172,9 +160,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
-            testable.PublicTcpPortToConnectionId[1000] = "connectionId0";
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
 
             Assert.That(testable.GetConnectionIdForTcp(1000), Is.EqualTo("connectionId0"));
         }
@@ -184,9 +170,7 @@ namespace TutoProxy.Server.Tests.Services {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
                 Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
-            testable.PublicTcpPortToConnectionId[1000] = "connectionId0";
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
 
             Assert.Throws<HubClientNotFoundException>(() => testable.GetConnectionIdForTcp(1001), "hub-client for Tcp(1001) not found");
         }
@@ -194,11 +178,9 @@ namespace TutoProxy.Server.Tests.Services {
         [Test]
         public async Task GetConnectionIdForUdp_Test() {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
-                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
+                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1, 65535), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
-            testable.PublicUdpPortToConnectionId[1000] = "connectionId0";
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
 
             Assert.That(testable.GetConnectionIdForUdp(1000), Is.EqualTo("connectionId0"));
         }
@@ -206,11 +188,9 @@ namespace TutoProxy.Server.Tests.Services {
         [Test]
         public async Task GetConnectionIdForUdp_Throws_HubClientNotFoundException_If_Port_Not_Bound() {
             await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
-                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1000, 4), null);
+                Enumerable.Range(1, 65535).ToList(), Enumerable.Range(1, 65535), null);
 
-            testable.PublicMorozovConnectedClients.TryAdd("connectionId0", new HubClient(localEndPoint, 
-                            Enumerable.Range(1000, 1).ToList(), Enumerable.Range(1000, 1), serviceProviderMock.Object));
-            testable.PublicUdpPortToConnectionId[1000] = "connectionId0";
+            await testable.Connect("connectionId0", "tcpquery=1000&udpquery=1000");
 
             Assert.Throws<HubClientNotFoundException>(() => testable.GetConnectionIdForUdp(1001), "hub-client for Udp(1001) not found");
         }
@@ -300,6 +280,78 @@ namespace TutoProxy.Server.Tests.Services {
                 .Count();
             Assert.That(clientsWithPort, Is.EqualTo(1),
                 $"Race condition: {clientsWithPort} clients registered with port {targetPort}");
+        }
+
+        [Test]
+        public async Task Parallel_Connections_From_Same_Client_Share_HubClient() {
+            await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
+                Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
+
+            // First connection (index 0) creates the HubClient
+            await testable.Connect("connectionId0", "tcpquery=1000&connindex=0&totalconn=4&clientid=client1");
+            // Additional connections join the existing group
+            await testable.Connect("connectionId1", "tcpquery=1000&connindex=1&totalconn=4&clientid=client1");
+            await testable.Connect("connectionId2", "tcpquery=1000&connindex=2&totalconn=4&clientid=client1");
+            await testable.Connect("connectionId3", "tcpquery=1000&connindex=3&totalconn=4&clientid=client1");
+
+            Assert.That(testable.PublicMorozovConnectedClients.Keys.Count, Is.EqualTo(4));
+
+            // All connections should share the same HubClient
+            var hubClient0 = testable.GetClient("connectionId0");
+            var hubClient1 = testable.GetClient("connectionId1");
+            var hubClient2 = testable.GetClient("connectionId2");
+            var hubClient3 = testable.GetClient("connectionId3");
+
+            Assert.That(hubClient0, Is.SameAs(hubClient1));
+            Assert.That(hubClient1, Is.SameAs(hubClient2));
+            Assert.That(hubClient2, Is.SameAs(hubClient3));
+        }
+
+        [Test]
+        public async Task GetConnectionIdForTcp_Returns_Different_Connections_Round_Robin() {
+            await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
+                Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
+
+            // Setup 4 parallel connections
+            await testable.Connect("connectionId0", "tcpquery=1000&connindex=0&totalconn=4&clientid=client1");
+            await testable.Connect("connectionId1", "tcpquery=1000&connindex=1&totalconn=4&clientid=client1");
+            await testable.Connect("connectionId2", "tcpquery=1000&connindex=2&totalconn=4&clientid=client1");
+            await testable.Connect("connectionId3", "tcpquery=1000&connindex=3&totalconn=4&clientid=client1");
+
+            // Get connection IDs in round-robin fashion
+            var ids = new HashSet<string>();
+            for(int i = 0; i < 8; i++) {
+                ids.Add(testable.GetConnectionIdForTcp(1000));
+            }
+
+            // Should have used all 4 connections
+            Assert.That(ids.Count, Is.EqualTo(4));
+            Assert.That(ids, Does.Contain("connectionId0"));
+            Assert.That(ids, Does.Contain("connectionId1"));
+            Assert.That(ids, Does.Contain("connectionId2"));
+            Assert.That(ids, Does.Contain("connectionId3"));
+        }
+
+        [Test]
+        public async Task TcpSession_Registration_Provides_Affinity() {
+            await using var testable = new TestableClientsService(loggerMock.Object, applicationLifetimeMock.Object, serviceProviderMock.Object, processMonitorMock.Object, localEndPoint,
+                Enumerable.Range(1, 65535), Enumerable.Range(1, 65535), null);
+
+            await testable.Connect("connectionId0", "tcpquery=1000&connindex=0&totalconn=2&clientid=client1");
+            await testable.Connect("connectionId1", "tcpquery=1000&connindex=1&totalconn=2&clientid=client1");
+
+            // Register a session with specific connection
+            testable.RegisterTcpSession(1000, 50000, "connectionId1");
+
+            // GetConnectionIdForTcpSession should return the registered connection
+            var connId = testable.GetConnectionIdForTcpSession(1000, 50000);
+            Assert.That(connId, Is.EqualTo("connectionId1"));
+
+            // Unregister and it should fall back to round-robin
+            testable.UnregisterTcpSession(1000, 50000);
+            // Now it will use round-robin (could be either)
+            var connIdAfter = testable.GetConnectionIdForTcpSession(1000, 50000);
+            Assert.That(connIdAfter, Does.StartWith("connectionId"));
         }
     }
 }

--- a/Projects/TutoProxy/TutoProxy.Server.Tests/TutoProxy.Server.Tests.csproj
+++ b/Projects/TutoProxy/TutoProxy.Server.Tests/TutoProxy.Server.Tests.csproj
@@ -14,11 +14,11 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.13.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="NUnit" Version="4.3.2" />
-    <PackageReference Include="NUnit3TestAdapter" Version="5.0.0" />
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="NUnit" Version="4.5.0" />
+    <PackageReference Include="NUnit3TestAdapter" Version="6.1.0" />
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/Projects/TutoProxy/TutoProxy.Server/CommandLine/AppRootCommand.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/CommandLine/AppRootCommand.cs
@@ -1,5 +1,4 @@
 ﻿using System.CommandLine;
-using System.CommandLine.Invocation;
 using System.Net;
 using System.Reflection;
 using MessagePack;
@@ -20,51 +19,48 @@ using TuToProxy.Core.ServiceProvider;
 
 namespace TutoProxy.Server.CommandLine {
     internal class AppRootCommand : RootCommand {
-        public AppRootCommand() : base("Connback proxy server TuTo") {
-            Add(new Argument<string>("host", "Local host address"));
-            var tcpOption = PortsArgument.CreateOption("--tcp", $"Allowed ports, format like '--tcp=80,81,443,8000-8100'");
-            var udpOption = PortsArgument.CreateOption("--udp", $"Allowed ports, format like '--udp=700-900,65500'");
-            Add(tcpOption);
-            Add(udpOption);
-            Add(AllowedClientsOption.Create("--clients", $"Allowed Clients IDs, format like '--clients=Client1,Client2'"));
-            Add(new Option<bool>("--daemon", () => false, "Run as a daemon"));
+        public Argument<string> HostArg { get; }
+        public Option<PortsArgument?> TcpOption { get; }
+        public Option<PortsArgument?> UdpOption { get; }
+        public Option<AllowedClientsOption?> ClientsOption { get; }
+        public Option<bool> DaemonOption { get; }
 
-            AddValidator((result) => {
+        public AppRootCommand() : base("Connback proxy server TuTo") {
+            HostArg = new Argument<string>("host") { Description = "Local host address" };
+            TcpOption = PortsArgument.CreateOption("--tcp", $"Allowed ports, format like '--tcp=80,81,443,8000-8100'");
+            UdpOption = PortsArgument.CreateOption("--udp", $"Allowed ports, format like '--udp=700-900,65500'");
+            ClientsOption = AllowedClientsOption.Create("--clients", $"Allowed Clients IDs, format like '--clients=Client1,Client2'");
+            DaemonOption = new Option<bool>("--daemon") { Description = "Run as a daemon", DefaultValueFactory = _ => false };
+
+            Add(HostArg);
+            Add(TcpOption);
+            Add(UdpOption);
+            Add(ClientsOption);
+            Add(DaemonOption);
+
+            Validators.Add((result) => {
                 try {
-                    if(!result.Children.Any(x => x.GetValueForOption(tcpOption) != null || x.GetValueForOption(udpOption) != null)) {
-                        result.ErrorMessage = "tcp or udp options requried";
+                    if(!result.Children.Any(x => x.GetValue(TcpOption) != null || x.GetValue(UdpOption) != null)) {
+                        result.AddError("tcp or udp options requried");
                     }
                 } catch(InvalidOperationException) {
-                    result.ErrorMessage = "not valid";
+                    result.AddError("not valid");
                 }
             });
         }
 
-        public new class Handler : ICommandHandler {
-            readonly Serilog.ILogger logger;
-            readonly IHostApplicationLifetime applicationLifetime;
+        public void ConfigureAction(Serilog.ILogger logger) {
+            SetAction(async (parseResult, cancellationToken) => {
+                var host = parseResult.GetValue(HostArg);
+                var tcp = parseResult.GetValue(TcpOption);
+                var udp = parseResult.GetValue(UdpOption);
+                var clients = parseResult.GetValue(ClientsOption);
+                var daemon = parseResult.GetValue(DaemonOption);
 
-            public string? Host { get; set; }
-            public PortsArgument? Udp { get; set; }
-            public PortsArgument? Tcp { get; set; }
-            public AllowedClientsOption? Clients { get; set; }
-            public bool? Daemon { get; set; }
+                Guard.NotNullOrEmpty(host, nameof(host));
+                Guard.NotNull(tcp ?? udp, "tcp ?? udp");
 
-            public Handler(
-                Serilog.ILogger logger,
-                IHostApplicationLifetime applicationLifetime
-                ) {
-                Guard.NotNull(logger, nameof(logger));
-                Guard.NotNull(applicationLifetime, nameof(applicationLifetime));
-                this.logger = logger;
-                this.applicationLifetime = applicationLifetime;
-            }
-
-            public async Task<int> InvokeAsync(InvocationContext context) {
-                Guard.NotNullOrEmpty(Host, nameof(Host));
-                Guard.NotNull(Tcp ?? Udp, "Tcp ?? Udp");
-
-                var title = $"Connback proxy server TuTo [{Host}], TCP ports: {Tcp}, UDP-ports: {Udp}{(Clients != null ? ", clients: " + Clients : "")}";
+                var title = $"Connback proxy server TuTo [{host}], TCP ports: {tcp}, UDP-ports: {udp}{(clients != null ? ", clients: " + clients : "")}";
                 var version = $"{Assembly.GetExecutingAssembly().GetName().Name} {Assembly.GetExecutingAssembly().GetName().Version}";
                 logger.Information(version);
                 logger.Information(title);
@@ -84,7 +80,6 @@ namespace TutoProxy.Server.CommandLine {
                       .AddHubOptions<SignalRHub>(options => {
                           options.MaximumReceiveMessageSize = 512 * 1024;
                           options.MaximumParallelInvocationsPerClient = 512;
-                          //options.EnableDetailedErrors = true;
                       })
                     .AddMessagePackProtocol(options => {
                         options.SerializerOptions = MessagePackSerializerOptions.Standard
@@ -95,32 +90,33 @@ namespace TutoProxy.Server.CommandLine {
                 builder.Services.AddSingleton<IDataTransferService, DataTransferService>();
                 builder.Services.AddSingleton<IProcessMonitor, ProcessMonitor>();
                 builder.Services.AddSingleton<IServerFactory, ServerFactory>();
+                builder.Services.AddSingleton((sp) => logger);
                 builder.Services.AddSingleton<IHubClientsService>((sp) => new HubClientsService(
                     sp.GetRequiredService<Serilog.ILogger>(),
                     sp.GetRequiredService<IHostApplicationLifetime>(),
                     sp.GetRequiredService<IServiceProvider>(),
                     sp.GetRequiredService<IProcessMonitor>(),
-                    new IPEndPoint(IpAddressHelpers.ParseUrl(Host!), 0),
-                    Tcp?.Ports,
-                    Udp?.Ports,
-                    Clients?.Clients)
+                    new IPEndPoint(IpAddressHelpers.ParseUrl(host!), 0),
+                    tcp?.Ports,
+                    udp?.Ports,
+                    clients?.Clients)
                 );
 
                 var app = builder.Build();
                 app.MapHub<SignalRHub>(SignalRParams.Path);
 
-                if(Daemon != null && Daemon.Value) {
+                if(daemon) {
                     Program.ConsoleLevelSwitch.MinimumLevel = Serilog.Events.LogEventLevel.Warning;
                     TcpSocketParams.TrafficMonitoring = false;
                     UdpSocketParams.TrafficMonitoring = false;
-                    await app.RunAsync(Host);
+                    await app.RunAsync(host);
                 } else {
                     Application.IsMouseDisabled = true;
                     Application.Init();
-                    var mainWindow = new MainWindow(title, Tcp?.Ports, Udp?.Ports);
+                    var mainWindow = new MainWindow(title, tcp?.Ports, udp?.Ports);
                     mainWindow.Ready += () => {
                         _ = Task.Run(async () => {
-                            await app.RunAsync(Host);
+                            await app.RunAsync(host);
                         });
                     };
 
@@ -130,7 +126,7 @@ namespace TutoProxy.Server.CommandLine {
                 }
 
                 return 0;
-            }
+            });
         }
     }
 }

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/HubClient.cs
@@ -13,6 +13,7 @@ namespace TutoProxy.Server.Communication {
         readonly FrozenDictionary<int, ITcpServer> tcpServers;
         readonly FrozenDictionary<int, IUdpServer> udpServers;
         readonly CancellationTokenSource cts;
+        int disposed = 0;
 
         public HubClient(IPEndPoint localEndPoint, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts,
                     IServiceProvider serviceProvider) {
@@ -38,6 +39,10 @@ namespace TutoProxy.Server.Communication {
         }
 
         public async ValueTask DisposeAsync() {
+            if(Interlocked.Exchange(ref disposed, 1) == 1) {
+                return;
+            }
+
             cts.Cancel();
             cts.Dispose();
 

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
@@ -61,7 +61,7 @@ namespace TutoProxy.Server.Hubs {
 
         public override async Task OnConnectedAsync() {
             try {
-                var queryString = Context.GetHttpContext()?.Request.QueryString.Value;
+                var queryString = (Context.GetHttpContext()?.Request.QueryString.Value) ?? throw new ClientConnectionException(Context.ConnectionId, "QueryString empty");
                 await clientsService.Connect(Context.ConnectionId, queryString);
             } catch(TuToException ex) {
                 logger.Error(ex.Message);

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/SignalRHub.cs
@@ -22,7 +22,7 @@ namespace TutoProxy.Server.Hubs {
         }
 
         public async Task UdpResponse(UdpDataResponseModel model) {
-            logger.Debug($"UdpResponse: {model}");
+            logger.Debug("UdpResponse: {model}", model);
             try {
                 await dataTransferService.HandleUdpResponse(Context.ConnectionId, model);
             } catch(TuToException ex) {
@@ -31,7 +31,7 @@ namespace TutoProxy.Server.Hubs {
         }
 
         public async Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
-            logger.Debug($"DisconnectUdp: {socketAddress}, {totalTransfered}");
+            logger.Debug("DisconnectUdp: {socketAddress}, {totalTransfered}", socketAddress, totalTransfered);
             try {
                 await dataTransferService.HandleDisconnectUdpAsync(Context.ConnectionId, socketAddress, totalTransfered);
             } catch(TuToException ex) {
@@ -40,7 +40,7 @@ namespace TutoProxy.Server.Hubs {
         }
 
         public async Task<int> TcpResponse(TcpDataResponseModel model) {
-            logger.Debug($"TcpResponse: {model}");
+            logger.Debug("TcpResponse: {model}", model);
             try {
                 return await dataTransferService.HandleTcpResponse(Context.ConnectionId, model);
             } catch(TuToException ex) {
@@ -50,7 +50,7 @@ namespace TutoProxy.Server.Hubs {
         }
 
         public async Task<bool> DisconnectTcp(SocketAddressModel socketAddress) {
-            logger.Debug($"DisconnectTcp: {socketAddress}");
+            logger.Debug("DisconnectTcp: {socketAddress}", socketAddress);
             try {
                 return await dataTransferService.HandleDisconnectTcp(Context.ConnectionId, socketAddress);
             } catch(TuToException ex) {

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/TcpClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/TcpClient.cs
@@ -4,6 +4,7 @@ using System.Net.Sockets;
 using TutoProxy.Server.Services;
 using TuToProxy.Core;
 using TuToProxy.Core.Extensions;
+using TuToProxy.Core.Pooling;
 
 namespace TutoProxy.Server.Communication {
 
@@ -62,9 +63,16 @@ namespace TutoProxy.Server.Communication {
                     totalReceived += receivedBytes;
                     var data = receiveBuffer[..receivedBytes];
 
-                    var transmitted = await dataTransferService.SendTcpRequest(new TcpDataRequestModel() {
-                        Port = server.Port, OriginPort = OriginPort, Data = data
-                    }, cancellationToken);
+                    var request = DataModelPool<TcpDataRequestModel>.Rent();
+                    request.Port = server.Port;
+                    request.OriginPort = OriginPort;
+                    request.Data = data;
+                    int transmitted;
+                    try {
+                        transmitted = await dataTransferService.SendTcpRequest(request, cancellationToken);
+                    } finally {
+                        DataModelPool<TcpDataRequestModel>.Return(request);
+                    }
                     if(receivedBytes != transmitted) {
                         logger.Error($"{this} request transmit error ({transmitted})");
                         throw new SocketException((int)SocketError.ConnectionAborted);

--- a/Projects/TutoProxy/TutoProxy.Server/Communication/UdpClient.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Communication/UdpClient.cs
@@ -3,6 +3,7 @@ using System.Timers;
 using TutoProxy.Server.Services;
 using TuToProxy.Core;
 using TuToProxy.Core.Extensions;
+using TuToProxy.Core.Pooling;
 
 namespace TutoProxy.Server.Communication {
 
@@ -64,10 +65,15 @@ namespace TutoProxy.Server.Communication {
         }
 
         public async Task SendRequestAsync(ReadOnlyMemory<byte> payload, CancellationToken cancellationToken) {
-            await dataTransferService.SendUdpRequest(new UdpDataRequestModel() {
-                Port = Port, OriginPort = OriginPort,
-                Data = payload
-            }, cancellationToken);
+            var request = DataModelPool<UdpDataRequestModel>.Rent();
+            request.Port = Port;
+            request.OriginPort = OriginPort;
+            request.Data = payload;
+            try {
+                await dataTransferService.SendUdpRequest(request, cancellationToken);
+            } finally {
+                DataModelPool<UdpDataRequestModel>.Return(request);
+            }
             totalReceived += payload.Length;
             if(UdpSocketParams.TrafficMonitoring && Environment.TickCount64 - requestLogTicks >= UdpSocketParams.LogUpdatePeriod * 1000) {
                 requestLogTicks = Environment.TickCount64;

--- a/Projects/TutoProxy/TutoProxy.Server/Program.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Program.cs
@@ -1,35 +1,24 @@
-﻿using System.CommandLine;
-using System.CommandLine.Builder;
-using System.CommandLine.Hosting;
-using System.CommandLine.Parsing;
-using Microsoft.Extensions.Hosting;
-using Serilog.Core;
+﻿using Serilog.Core;
 using Serilog.Events;
 using TutoProxy.Server.CommandLine;
-using TuToProxy.Core.ServiceProvider;
 
 class Program {
     public static readonly LoggingLevelSwitch ConsoleLevelSwitch
         = new LoggingLevelSwitch(LogEventLevel.Fatal);
 
     public static async Task<int> Main(string[] args) {
-        var runner = new CommandLineBuilder(new AppRootCommand())
-            .UseHost(_ => new HostBuilder(), builder => builder
-                .UseCommandHandler<AppRootCommand, AppRootCommand.Handler>()
-                .UseSerilog((_, config) => config
-                    .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}", levelSwitch: ConsoleLevelSwitch)
-                    .WriteTo.File("log-.txt", rollingInterval: RollingInterval.Day,
-                             restrictedToMinimumLevel: Serilog.Events.LogEventLevel.Warning)
-                )
-                .UseServiceProviderFactory(context => {
-                    var factory = ServiceProviderFactory.Instance;
-                    return ServiceProviderFactory.Instance;
-                })
-            )
-            .UseDefaults()
-            .Build();
+        var logger = new Serilog.LoggerConfiguration()
+            .WriteTo.Console(outputTemplate: "[{Timestamp:HH:mm:ss} {Level:u1}]{Message:lj}{NewLine}{Exception}", levelSwitch: ConsoleLevelSwitch)
+            .WriteTo.File("log-.txt", rollingInterval: Serilog.RollingInterval.Day,
+                     restrictedToMinimumLevel: LogEventLevel.Warning)
+            .CreateLogger();
 
-        return await runner.InvokeAsync(args);
+        Serilog.Log.Logger = logger;
+
+        var command = new AppRootCommand();
+        command.ConfigureAction(logger);
+
+        var parseResult = command.Parse(args);
+        return await parseResult.InvokeAsync();
     }
-
 }

--- a/Projects/TutoProxy/TutoProxy.Server/Properties/launchSettings.json
+++ b/Projects/TutoProxy/TutoProxy.Server/Properties/launchSettings.json
@@ -2,7 +2,7 @@
   "profiles": {
     "TutoProxy.Server": {
       "commandName": "Project",
-      "commandLineArgs": "http://127.0.0.1:8088 --tcp=8001 --clients=ClientSec",
+      "commandLineArgs": "http://192.168.0.107:8088 --tcp=5201 --udp=5201 --clients=ClientSec",
       "hotReloadEnabled": false
     }
   }

--- a/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
@@ -61,15 +61,23 @@ namespace TutoProxy.Server.Services {
             await client.DisconnectUdpAsync(socketAddress, totalTransfered);
         }
 
-        public Task<SocketError> ConnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
+        public async Task<SocketError> ConnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
             logger.Debug("ConnectTcp :{SocketAddress}", socketAddress);
+            // Get connectionId using round-robin and register this session
             var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
-            return rawHub.Clients.Client(connectionId).InvokeAsync<SocketError>(ClientMethods.ConnectTcp, socketAddress, cancellationToken);
+            clientsService.RegisterTcpSession(socketAddress.Port, socketAddress.OriginPort, connectionId);
+            try {
+                return await rawHub.Clients.Client(connectionId).InvokeAsync<SocketError>(ClientMethods.ConnectTcp, socketAddress, cancellationToken);
+            } catch {
+                clientsService.UnregisterTcpSession(socketAddress.Port, socketAddress.OriginPort);
+                throw;
+            }
         }
 
         public async Task<int> SendTcpRequest(TcpDataRequestModel request, CancellationToken cancellationToken) {
             logger.Debug("TcpRequest :{Request}", request);
-            var connectionId = clientsService.GetConnectionIdForTcp(request.Port);
+            // Use registered session connectionId for session affinity
+            var connectionId = clientsService.GetConnectionIdForTcpSession(request.Port, request.OriginPort);
             return await rawHub.Clients.Client(connectionId).InvokeAsync<int>(ClientMethods.TcpRequest, request, cancellationToken);
         }
 
@@ -78,14 +86,21 @@ namespace TutoProxy.Server.Services {
             return client.SendTcpResponse(response);
         }
 
-        public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
+        public async Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
             logger.Debug("DisconnectTcp :{SocketAddress}", socketAddress);
-            var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
-            return rawHub.Clients.Client(connectionId).InvokeAsync<bool>(ClientMethods.DisconnectTcp, socketAddress, cancellationToken);
+            // Use registered session connectionId
+            var connectionId = clientsService.GetConnectionIdForTcpSession(socketAddress.Port, socketAddress.OriginPort);
+            try {
+                return await rawHub.Clients.Client(connectionId).InvokeAsync<bool>(ClientMethods.DisconnectTcp, socketAddress, cancellationToken);
+            } finally {
+                clientsService.UnregisterTcpSession(socketAddress.Port, socketAddress.OriginPort);
+            }
         }
 
         public ValueTask<bool> HandleDisconnectTcp(string connectionId, SocketAddressModel socketAddress) {
             var client = clientsService.GetClient(connectionId);
+            // Also unregister the session when client initiates disconnect
+            clientsService.UnregisterTcpSession(socketAddress.Port, socketAddress.OriginPort);
             return client.DisconnectTcp(socketAddress);
         }
     }

--- a/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/DataTransferService.cs
@@ -40,13 +40,13 @@ namespace TutoProxy.Server.Services {
         }
 
         public async Task SendUdpRequest(UdpDataRequestModel request, CancellationToken cancellationToken) {
-            logger.Debug($"UdpRequest :{request}");
+            logger.Debug("UdpRequest :{request}", request);
             var connectionId = clientsService.GetConnectionIdForUdp(request.Port);
             await typedHub.Clients.Client(connectionId).UdpRequest(request);
         }
 
         public async Task DisconnectUdp(SocketAddressModel socketAddress, Int64 totalTransfered) {
-            logger.Debug($"DisconnectUdp :{socketAddress}, {totalTransfered}");
+            logger.Debug("DisconnectUdp :{socketAddress}, {totalTransfered}", socketAddress, totalTransfered);
             var connectionId = clientsService.GetConnectionIdForUdp(socketAddress.Port);
             await typedHub.Clients.Client(connectionId).DisconnectUdp(socketAddress, totalTransfered);
         }
@@ -62,13 +62,13 @@ namespace TutoProxy.Server.Services {
         }
 
         public Task<SocketError> ConnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
-            logger.Debug($"ConnectTcp :{socketAddress}");
+            logger.Debug("ConnectTcp :{SocketAddress}", socketAddress);
             var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
             return rawHub.Clients.Client(connectionId).InvokeAsync<SocketError>(ClientMethods.ConnectTcp, socketAddress, cancellationToken);
         }
 
         public async Task<int> SendTcpRequest(TcpDataRequestModel request, CancellationToken cancellationToken) {
-            logger.Debug($"TcpRequest :{request}");
+            logger.Debug("TcpRequest :{Request}", request);
             var connectionId = clientsService.GetConnectionIdForTcp(request.Port);
             return await rawHub.Clients.Client(connectionId).InvokeAsync<int>(ClientMethods.TcpRequest, request, cancellationToken);
         }
@@ -79,7 +79,7 @@ namespace TutoProxy.Server.Services {
         }
 
         public Task<bool> DisconnectTcp(SocketAddressModel socketAddress, CancellationToken cancellationToken) {
-            logger.Debug($"DisconnectTcp :{socketAddress}");
+            logger.Debug("DisconnectTcp :{SocketAddress}", socketAddress);
             var connectionId = clientsService.GetConnectionIdForTcp(socketAddress.Port);
             return rawHub.Clients.Client(connectionId).InvokeAsync<bool>(ClientMethods.DisconnectTcp, socketAddress, cancellationToken);
         }

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -121,9 +121,9 @@ namespace TutoProxy.Server.Services {
 
         public async Task Connect(string connectionId, string queryString) {
             var query = QueryHelpers.ParseQuery(queryString);
-            var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery);
-            var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery);
-            var clientIdPresent = query.TryGetValue(SignalRParams.ClientId, out StringValues clientId);
+            var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery) && !string.IsNullOrEmpty(tcpQuery);
+            var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery) && !string.IsNullOrEmpty(udpQuery);
+            var clientIdPresent = query.TryGetValue(SignalRParams.ClientId, out StringValues clientId) && !string.IsNullOrEmpty(clientId);
             query.TryGetValue(SignalRParams.ConnectionIndex, out StringValues connIndexStr);
             query.TryGetValue(SignalRParams.TotalConnections, out StringValues totalConnStr);
 

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -10,7 +10,7 @@ using TuToProxy.Core.Exceptions;
 
 namespace TutoProxy.Server.Services {
     public interface IHubClientsService : IAsyncDisposable {
-        Task Connect(string connectionId, string? queryString);
+        Task Connect(string connectionId, string queryString);
         Task DisconnectAsync(string connectionId);
         HubClient GetClient(string connectionId);
         string GetConnectionIdForTcp(int port);
@@ -119,10 +119,7 @@ namespace TutoProxy.Server.Services {
             return $"{clientId ?? ""}:{tcpQuery ?? ""}:{udpQuery ?? ""}";
         }
 
-        public async Task Connect(string connectionId, string? queryString) {
-            if(queryString == null) {
-                throw new ClientConnectionException(connectionId, "QueryString empty");
-            }
+        public async Task Connect(string connectionId, string queryString) {
             var query = QueryHelpers.ParseQuery(queryString);
             var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery);
             var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery);

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -121,14 +121,21 @@ namespace TutoProxy.Server.Services {
 
         public async Task Connect(string connectionId, string queryString) {
             var query = QueryHelpers.ParseQuery(queryString);
-            var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery) && !string.IsNullOrEmpty(tcpQuery);
-            var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery) && !string.IsNullOrEmpty(udpQuery);
-            var clientIdPresent = query.TryGetValue(SignalRParams.ClientId, out StringValues clientId) && !string.IsNullOrEmpty(clientId);
-            query.TryGetValue(SignalRParams.ConnectionIndex, out StringValues connIndexStr);
-            query.TryGetValue(SignalRParams.TotalConnections, out StringValues totalConnStr);
+            var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery);
+            var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery);
+            var clientIdPresent = query.TryGetValue(SignalRParams.ClientId, out StringValues clientId);
 
-            int connIndex = int.TryParse(connIndexStr.FirstOrDefault(), out var ci) ? ci : 0;
-            int totalConn = int.TryParse(totalConnStr.FirstOrDefault(), out var tc) ? tc : 1;
+            if (!query.TryGetValue(SignalRParams.ConnectionIndex, out StringValues connIndexStr) 
+                || !int.TryParse(connIndexStr.FirstOrDefault(), out var connIndex)) {       
+                connIndex = 0; 
+                logger.Information($"Connect use default connIndex param value = {connIndex}");        
+            }
+
+            if (!query.TryGetValue(SignalRParams.TotalConnections, out StringValues totalConnStr)
+                || !int.TryParse(totalConnStr.FirstOrDefault(), out var totalConn)) {        
+                totalConn = 1;      
+                logger.Information($"Connect use default totalConn param value = {totalConn}");      
+            }
 
             if(alowedClients != null) {
                 if(!clientIdPresent) {

--- a/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
+++ b/Projects/TutoProxy/TutoProxy.Server/Services/HubClientsService.cs
@@ -15,13 +15,73 @@ namespace TutoProxy.Server.Services {
         HubClient GetClient(string connectionId);
         string GetConnectionIdForTcp(int port);
         string GetConnectionIdForUdp(int port);
+        string GetConnectionIdForTcpSession(int port, int originPort);
+        void RegisterTcpSession(int port, int originPort, string connectionId);
+        void UnregisterTcpSession(int port, int originPort);
     }
 
     public class HubClientsService : IHubClientsService {
+        // Represents a group of SignalR connections from the same client
+        class ClientGroup {
+            readonly object _lock = new();
+            readonly List<string> connectionIds = new();
+
+            public HubClient HubClient { get; }
+            public IEnumerable<int>? TcpPorts { get; }
+            public IEnumerable<int>? UdpPorts { get; }
+            public int ExpectedConnections { get; }
+            int roundRobinIndex = 0;
+
+            public ClientGroup(HubClient hubClient, IEnumerable<int>? tcpPorts, IEnumerable<int>? udpPorts, int expectedConnections) {
+                HubClient = hubClient;
+                TcpPorts = tcpPorts;
+                UdpPorts = udpPorts;
+                ExpectedConnections = expectedConnections;
+            }
+
+            public void AddConnectionId(string connectionId) {
+                lock(_lock) {
+                    connectionIds.Add(connectionId);
+                }
+            }
+
+            public bool RemoveConnectionId(string connectionId) {
+                lock(_lock) {
+                    return connectionIds.Remove(connectionId);
+                }
+            }
+
+            public bool ContainsConnectionId(string connectionId) {
+                lock(_lock) {
+                    return connectionIds.Contains(connectionId);
+                }
+            }
+
+            public int ConnectionCount {
+                get {
+                    lock(_lock) {
+                        return connectionIds.Count;
+                    }
+                }
+            }
+
+            public string GetNextConnectionId() {
+                lock(_lock) {
+                    if(connectionIds.Count == 0) {
+                        throw new InvalidOperationException("No connections available");
+                    }
+                    var index = Interlocked.Increment(ref roundRobinIndex) % connectionIds.Count;
+                    return connectionIds[index];
+                }
+            }
+        }
+
         readonly ILogger logger;
         protected readonly ConcurrentDictionary<string, HubClient> connectedClients = new();
-        protected readonly ConcurrentDictionary<int, string> tcpPortToConnectionId = new();
-        protected readonly ConcurrentDictionary<int, string> udpPortToConnectionId = new();
+        readonly ConcurrentDictionary<string, ClientGroup> clientGroups = new();  // clientGroupKey -> ClientGroup
+        readonly ConcurrentDictionary<int, ClientGroup> tcpPortToClientGroup = new();
+        readonly ConcurrentDictionary<int, ClientGroup> udpPortToClientGroup = new();
+        readonly ConcurrentDictionary<(int port, int originPort), string> tcpSessionToConnectionId = new();
         readonly IHostApplicationLifetime applicationLifetime;
         readonly IServiceProvider serviceProvider;
         readonly IProcessMonitor processMonitor;
@@ -55,6 +115,10 @@ namespace TutoProxy.Server.Services {
             this.alowedClients = alowedClients?.ToHashSet();
         }
 
+        static string GetClientGroupKey(string? clientId, string? tcpQuery, string? udpQuery) {
+            return $"{clientId ?? ""}:{tcpQuery ?? ""}:{udpQuery ?? ""}";
+        }
+
         public async Task Connect(string connectionId, string? queryString) {
             if(queryString == null) {
                 throw new ClientConnectionException(connectionId, "QueryString empty");
@@ -63,6 +127,11 @@ namespace TutoProxy.Server.Services {
             var tcpPresent = query.TryGetValue(SignalRParams.TcpQuery, out StringValues tcpQuery);
             var udpPresent = query.TryGetValue(SignalRParams.UdpQuery, out StringValues udpQuery);
             var clientIdPresent = query.TryGetValue(SignalRParams.ClientId, out StringValues clientId);
+            query.TryGetValue(SignalRParams.ConnectionIndex, out StringValues connIndexStr);
+            query.TryGetValue(SignalRParams.TotalConnections, out StringValues totalConnStr);
+
+            int connIndex = int.TryParse(connIndexStr.FirstOrDefault(), out var ci) ? ci : 0;
+            int totalConn = int.TryParse(totalConnStr.FirstOrDefault(), out var tc) ? tc : 1;
 
             if(alowedClients != null) {
                 if(!clientIdPresent) {
@@ -100,59 +169,136 @@ namespace TutoProxy.Server.Services {
                 throw new ClientConnectionException(clientId, connectionId, "one of udp ports is not allowed");
             }
 
-            if(tcpPorts != null) {
-                foreach(var port in tcpPorts) {
-                    if (!tcpPortToConnectionId.TryAdd(port, connectionId)) {
-                        throw new ClientConnectionException(clientId, connectionId, $"tcp port '{port}' already used");
-                    }
-                }
-            }
-            if(udpPorts != null) {
-                foreach(var port in udpPorts) {
-                    if (!udpPortToConnectionId.TryAdd(port, connectionId)) {
-                        throw new ClientConnectionException(clientId, connectionId, $"udp port '{port}' already used");
-                    }
-                }
-            }
+            var groupKey = GetClientGroupKey(clientId.FirstOrDefault(), tcpQuery.FirstOrDefault(), udpQuery.FirstOrDefault());
 
-            var hubClient = new HubClient(localEndPoint, tcpPorts, udpPorts, serviceProvider);
-            if(!connectedClients.TryAdd(connectionId, hubClient)) {
-                await hubClient.DisposeAsync();
-
+            if(connIndex == 0) {
+                // First connection - create HubClient and ClientGroup
                 if(tcpPorts != null) {
                     foreach(var port in tcpPorts) {
-                        tcpPortToConnectionId.TryRemove(port, out _);
+                        if(tcpPortToClientGroup.ContainsKey(port)) {
+                            throw new ClientConnectionException(clientId, connectionId, $"tcp port '{port}' already used");
+                        }
                     }
                 }
                 if(udpPorts != null) {
                     foreach(var port in udpPorts) {
-                        udpPortToConnectionId.TryRemove(port, out _);
+                        if(udpPortToClientGroup.ContainsKey(port)) {
+                            throw new ClientConnectionException(clientId, connectionId, $"udp port '{port}' already used");
+                        }
                     }
                 }
-                throw new ClientConnectionException(clientId, connectionId, "Client already connected");
-            } else {
-                logger.Information($"Connect [{(clientIdPresent ? clientId.FirstOrDefault() : "")}] :{connectionId} (tcp:{tcpQuery}, udp:{udpQuery})");
+
+                var hubClient = new HubClient(localEndPoint, tcpPorts, udpPorts, serviceProvider);
+                var clientGroup = new ClientGroup(hubClient, tcpPorts, udpPorts, totalConn);
+                clientGroup.AddConnectionId(connectionId);
+
+                if(!clientGroups.TryAdd(groupKey, clientGroup)) {
+                    await hubClient.DisposeAsync();
+                    throw new ClientConnectionException(clientId, connectionId, "Client group already exists");
+                }
+
+                if(!connectedClients.TryAdd(connectionId, hubClient)) {
+                    clientGroups.TryRemove(groupKey, out _);
+                    await hubClient.DisposeAsync();
+                    throw new ClientConnectionException(clientId, connectionId, "Client already connected");
+                }
+
+                // Register port mappings
+                if(tcpPorts != null) {
+                    foreach(var port in tcpPorts) {
+                        tcpPortToClientGroup[port] = clientGroup;
+                    }
+                }
+                if(udpPorts != null) {
+                    foreach(var port in udpPorts) {
+                        udpPortToClientGroup[port] = clientGroup;
+                    }
+                }
+
+                logger.Information($"Connect [{(clientIdPresent ? clientId.FirstOrDefault() : "")}] :{connectionId} [0/{totalConn}] (tcp:{tcpQuery}, udp:{udpQuery})");
                 _ = hubClient.Listen();
                 processMonitor.ConnectHubClient(connectionId, tcpPorts, udpPorts);
+
+            } else {
+                // Additional connection - join existing ClientGroup
+                // Wait for connection 0 to create the group (with timeout)
+                ClientGroup? existingGroup = null;
+                const int maxRetries = 50;  // 5 seconds total (50 * 100ms)
+                for(int retry = 0; retry < maxRetries; retry++) {
+                    if(clientGroups.TryGetValue(groupKey, out existingGroup)) {
+                        break;
+                    }
+                    await Task.Delay(100);
+                }
+
+                if(existingGroup == null) {
+                    throw new ClientConnectionException(clientId, connectionId, $"Client group not found. Connection 0 must connect first.");
+                }
+
+                existingGroup.AddConnectionId(connectionId);
+
+                if(!connectedClients.TryAdd(connectionId, existingGroup.HubClient)) {
+                    existingGroup.RemoveConnectionId(connectionId);
+                    throw new ClientConnectionException(clientId, connectionId, "Client already connected");
+                }
+
+                logger.Information($"Connect [{(clientIdPresent ? clientId.FirstOrDefault() : "")}] :{connectionId} [{connIndex}/{totalConn}] (joined existing group)");
+                processMonitor.ConnectHubClient(connectionId, null, null);  // Don't report ports for additional connections
             }
         }
 
         public async Task DisconnectAsync(string connectionId) {
             logger.Information($"Disconnect hubClient :{connectionId}");
-            if(connectedClients.TryRemove(connectionId, out HubClient? hubClient)) {                
-                if(hubClient.TcpPorts != null) {
-                    foreach(var port in hubClient.TcpPorts) {
-                        tcpPortToConnectionId.TryRemove(port, out _);
+
+            if(!connectedClients.TryRemove(connectionId, out HubClient? hubClient)) {
+                return;
+            }
+
+            // Find and update the client group
+            ClientGroup? groupToRemove = null;
+            string? groupKeyToRemove = null;
+
+            foreach(var kvp in clientGroups) {
+                if(kvp.Value.ContainsConnectionId(connectionId)) {
+                    kvp.Value.RemoveConnectionId(connectionId);
+
+                    // Clean up session mappings for this connection
+                    var sessionsToRemove = tcpSessionToConnectionId
+                        .Where(s => s.Value == connectionId)
+                        .Select(s => s.Key)
+                        .ToList();
+                    foreach(var session in sessionsToRemove) {
+                        tcpSessionToConnectionId.TryRemove(session, out _);
+                    }
+
+                    // If this was the last connection, mark group for removal
+                    if(kvp.Value.ConnectionCount == 0) {
+                        groupToRemove = kvp.Value;
+                        groupKeyToRemove = kvp.Key;
+                    }
+                    break;
+                }
+            }
+
+            processMonitor.DisconnectHubClient(connectionId, null, null);
+
+            // Clean up if last connection
+            if(groupToRemove != null && groupKeyToRemove != null) {
+                clientGroups.TryRemove(groupKeyToRemove, out _);
+
+                if(groupToRemove.TcpPorts != null) {
+                    foreach(var port in groupToRemove.TcpPorts) {
+                        tcpPortToClientGroup.TryRemove(port, out _);
                     }
                 }
-                if(hubClient.UdpPorts != null) {
-                    foreach(var port in hubClient.UdpPorts) {
-                        udpPortToConnectionId.TryRemove(port, out _);
+                if(groupToRemove.UdpPorts != null) {
+                    foreach(var port in groupToRemove.UdpPorts) {
+                        udpPortToClientGroup.TryRemove(port, out _);
                     }
                 }
 
-                processMonitor.DisconnectHubClient(connectionId, hubClient.TcpPorts, hubClient.UdpPorts);
-                await hubClient.DisposeAsync();
+                processMonitor.DisconnectHubClient(connectionId, groupToRemove.TcpPorts, groupToRemove.UdpPorts);
+                await groupToRemove.HubClient.DisposeAsync();
             }
         }
 
@@ -169,9 +315,11 @@ namespace TutoProxy.Server.Services {
         }
 
         public async ValueTask DisposeAsync() {
-            foreach(var hubClient in connectedClients.Values) {
-                await hubClient.DisposeAsync();
+            foreach(var group in clientGroups.Values) {
+                await group.HubClient.DisposeAsync();
             }
+            clientGroups.Clear();
+            connectedClients.Clear();
         }
 
         public HubClient GetClient(string connectionId) {
@@ -182,17 +330,34 @@ namespace TutoProxy.Server.Services {
         }
 
         public string GetConnectionIdForTcp(int port) {
-            if(!tcpPortToConnectionId.TryGetValue(port, out var connectionId)) {
+            if(!tcpPortToClientGroup.TryGetValue(port, out var clientGroup)) {
                 throw new HubClientNotFoundException(DataProtocol.Tcp, port);
             }
-            return connectionId;
+            return clientGroup.GetNextConnectionId();
         }
 
         public string GetConnectionIdForUdp(int port) {
-            if(!udpPortToConnectionId.TryGetValue(port, out var connectionId)) {
+            if(!udpPortToClientGroup.TryGetValue(port, out var clientGroup)) {
                 throw new HubClientNotFoundException(DataProtocol.Udp, port);
             }
-            return connectionId;
+            return clientGroup.GetNextConnectionId();
+        }
+
+        public string GetConnectionIdForTcpSession(int port, int originPort) {
+            // First check if session is already registered
+            if(tcpSessionToConnectionId.TryGetValue((port, originPort), out var connId)) {
+                return connId;
+            }
+            // Fall back to round-robin for new sessions
+            return GetConnectionIdForTcp(port);
+        }
+
+        public void RegisterTcpSession(int port, int originPort, string connectionId) {
+            tcpSessionToConnectionId[(port, originPort)] = connectionId;
+        }
+
+        public void UnregisterTcpSession(int port, int originPort) {
+            tcpSessionToConnectionId.TryRemove((port, originPort), out _);
         }
     }
 }

--- a/Projects/TutoProxy/TutoProxy.Server/TutoProxy.Server.csproj
+++ b/Projects/TutoProxy/TutoProxy.Server/TutoProxy.Server.csproj
@@ -5,7 +5,15 @@
     <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
-    <Version>1.0.1</Version>
+    <Version>1.0.4</Version>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Debug|AnyCPU'">
+    <Optimize>True</Optimize>
+  </PropertyGroup>
+
+  <PropertyGroup Condition="'$(Configuration)|$(Platform)'=='Release|AnyCPU'">
+    <Optimize>False</Optimize>
   </PropertyGroup>
 
   <ItemGroup>

--- a/Projects/TutoProxy/TutoProxy.Server/TutoProxy.Server.csproj
+++ b/Projects/TutoProxy/TutoProxy.Server/TutoProxy.Server.csproj
@@ -9,12 +9,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="9.0.4" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting" Version="9.0.4" />
-    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="9.0.4" />
-    <PackageReference Include="System.Linq.Async" Version="6.0.1" />
-    <PackageReference Include="Terminal.Gui" Version="1.18.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Owin" Version="10.0.3" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.MessagePack" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting" Version="10.0.3" />
+    <PackageReference Include="Microsoft.Extensions.Hosting.Abstractions" Version="10.0.3" />
+    <PackageReference Include="System.Linq.Async" Version="7.0.0" />
+    <PackageReference Include="Terminal.Gui" Version="1.19.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Projects/TutoProxy/scripts/perf-test.sh
+++ b/Projects/TutoProxy/scripts/perf-test.sh
@@ -3,7 +3,8 @@
 # Performance test for TutoProxy using iperf3
 #
 # Architecture:
-#   iperf3-client → TutoProxy.Server:5201 → SignalR → TutoProxy.Client → iperf3-server:5201
+#   TCP/UDP: iperf3-client → TutoProxy.Server:5201 → SignalR → TutoProxy.Client → iperf3-server:5201
+#   Reverse: iperf3-server:5201 → TutoProxy.Client → SignalR → TutoProxy.Server:5201 → iperf3-client
 #
 # We use Docker for iperf3-server to avoid port conflicts on localhost
 
@@ -13,6 +14,8 @@ SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 PROJECT_DIR="$(cd "$SCRIPT_DIR/.." && pwd)"
 
 # Configuration
+# TCP and UDP use the same port (they don't conflict as different protocols)
+# This matches iperf3-server which listens on 5201 for both TCP and UDP
 TUNNEL_PORT=5201
 SERVER_HTTP_PORT=5088
 DOCKER_NETWORK="tutoproxy-test"
@@ -113,19 +116,20 @@ setup_docker() {
         exit 1
     fi
 
-    log_info "iperf3 server started at $IPERF_SERVER_IP:5201 (Docker network)"
+    log_info "iperf3 server started at $IPERF_SERVER_IP:5201 (Docker network, TCP+UDP)"
 
     # Wait for server to be ready
     sleep 2
 }
 
 start_tutoproxy_server() {
-    log_info "Starting TutoProxy.Server on port $SERVER_HTTP_PORT (tunneling TCP:$TUNNEL_PORT)..."
+    log_info "Starting TutoProxy.Server on port $SERVER_HTTP_PORT (TCP+UDP:$TUNNEL_PORT)..."
 
     dotnet run --project "$PROJECT_DIR/TutoProxy.Server/TutoProxy.Server.csproj" \
         -c Release --no-build -- \
         "http://127.0.0.1:$SERVER_HTTP_PORT" \
         --tcp="$TUNNEL_PORT" \
+        --udp="$TUNNEL_PORT" \
         --daemon &
 
     SERVER_PID=$!
@@ -152,6 +156,7 @@ start_tutoproxy_client() {
         "http://127.0.0.1:$SERVER_HTTP_PORT" \
         "$IPERF_SERVER_IP" \
         --tcp="$TUNNEL_PORT" \
+        --udp="$TUNNEL_PORT" \
         --id="PerfTestClient" \
         --protocol="$protocol" \
         --daemon &
@@ -183,33 +188,93 @@ stop_tutoproxy() {
     fi
 }
 
-run_iperf_test() {
+run_iperf_tcp_test() {
     local duration=${1:-10}
     local parallel=${2:-1}
+    local reverse=${3:-false}
+    local reverse_flag=""
+    local direction="client → server (upload)"
 
-    log_info "Running iperf3 test (duration: ${duration}s, parallel: ${parallel})..."
+    if [ "$reverse" = "true" ]; then
+        reverse_flag="-R"
+        direction="server → client (download)"
+    fi
+
+    log_info "Running iperf3 TCP test (duration: ${duration}s, parallel: ${parallel}, direction: ${direction})..."
     echo ""
 
     # Connect to TutoProxy.Server which tunnels to iperf3 server
-    iperf3 -c 127.0.0.1 -p "$TUNNEL_PORT" -t "$duration" -P "$parallel"
+    iperf3 -c 127.0.0.1 -p "$TUNNEL_PORT" -t "$duration" -P "$parallel" $reverse_flag
 
     echo ""
 }
 
-run_protocol_test() {
+run_iperf_udp_test() {
+    local duration=${1:-10}
+    local bandwidth=${2:-100M}
+    local reverse=${3:-false}
+    local reverse_flag=""
+    local direction="client → server (upload)"
+
+    if [ "$reverse" = "true" ]; then
+        reverse_flag="-R"
+        direction="server → client (download)"
+    fi
+
+    log_info "Running iperf3 UDP test (duration: ${duration}s, bandwidth: ${bandwidth}, direction: ${direction})..."
+    echo ""
+
+    # Connect to TutoProxy.Server which tunnels to iperf3 server
+    # -u for UDP, -b for bandwidth limit
+    iperf3 -c 127.0.0.1 -p "$TUNNEL_PORT" -u -t "$duration" -b "$bandwidth" $reverse_flag
+
+    echo ""
+}
+
+run_tcp_protocol_test() {
     local protocol="$1"
     local duration="$2"
     local parallel="$3"
+    local reverse="${4:-false}"
+    local direction_label=""
+
+    if [ "$reverse" = "true" ]; then
+        direction_label=" [REVERSE]"
+    fi
 
     echo ""
     echo "========================================="
-    echo "  TUNNEL TEST ($protocol protocol)"
+    echo "  TCP TUNNEL TEST ($protocol)$direction_label"
     echo "========================================="
 
     start_tutoproxy_server
     start_tutoproxy_client "$protocol"
 
-    run_iperf_test "$duration" "$parallel"
+    run_iperf_tcp_test "$duration" "$parallel" "$reverse"
+
+    stop_tutoproxy
+}
+
+run_udp_protocol_test() {
+    local protocol="$1"
+    local duration="$2"
+    local bandwidth="$3"
+    local reverse="${4:-false}"
+    local direction_label=""
+
+    if [ "$reverse" = "true" ]; then
+        direction_label=" [REVERSE]"
+    fi
+
+    echo ""
+    echo "========================================="
+    echo "  UDP TUNNEL TEST ($protocol)$direction_label"
+    echo "========================================="
+
+    start_tutoproxy_server
+    start_tutoproxy_client "$protocol"
+
+    run_iperf_udp_test "$duration" "$bandwidth" "$reverse"
 
     stop_tutoproxy
 }
@@ -217,20 +282,26 @@ run_protocol_test() {
 print_usage() {
     echo "Usage: $0 [command] [options]"
     echo ""
-    echo "Commands:"
-    echo "  full       Run full test (Auto + Http + WebSocket)"
-    echo "  auto       Run tunnel test with Auto protocol"
-    echo "  http       Run tunnel test with Http protocol (LongPolling)"
-    echo "  websocket  Run tunnel test with WebSocket protocol (fastest)"
+    echo "Commands (TCP):"
+    echo "  full            Run full TCP test (Auto + Http + WebSocket)"
+    echo "  full-reverse    Run full TCP test in reverse direction"
+    echo "  websocket       Run TCP test with WebSocket protocol (fastest)"
+    echo "  websocket-reverse  Run TCP WebSocket test in reverse direction"
+    echo ""
+    echo "Commands (UDP):"
+    echo "  udp-full        Run full UDP test (Auto + Http + WebSocket)"
+    echo "  udp-full-reverse  Run full UDP test in reverse direction"
     echo ""
     echo "Options:"
     echo "  -d, --duration    Test duration in seconds (default: 10)"
-    echo "  -p, --parallel    Number of parallel streams (default: 1)"
+    echo "  -p, --parallel    Number of parallel TCP streams (default: 1)"
+    echo "  -b, --bandwidth   UDP bandwidth limit (default: 100M)"
     echo ""
     echo "Examples:"
     echo "  $0 full"
+    echo "  $0 full-reverse"
     echo "  $0 websocket -d 30 -p 4"
-    echo "  $0 auto -d 5"
+    echo "  $0 udp-full -d 10 -b 1000M"
 }
 
 main() {
@@ -239,6 +310,7 @@ main() {
 
     local duration=10
     local parallel=1
+    local bandwidth="100M"
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -248,6 +320,10 @@ main() {
                 ;;
             -p|--parallel)
                 parallel="$2"
+                shift 2
+                ;;
+            -b|--bandwidth)
+                bandwidth="$2"
                 shift 2
                 ;;
             -h|--help)
@@ -267,19 +343,31 @@ main() {
     setup_docker
 
     case $command in
-        auto)
-            run_protocol_test "Auto" "$duration" "$parallel"
+        full)
+            run_tcp_protocol_test "Auto" "$duration" "$parallel"
+            run_tcp_protocol_test "Http" "$duration" "$parallel"
+            run_tcp_protocol_test "WebSocket" "$duration" "$parallel"
             ;;
-        http)
-            run_protocol_test "Http" "$duration" "$parallel"
+        full-reverse)
+            run_tcp_protocol_test "Auto" "$duration" "$parallel" "true"
+            run_tcp_protocol_test "Http" "$duration" "$parallel" "true"
+            run_tcp_protocol_test "WebSocket" "$duration" "$parallel" "true"
             ;;
         websocket)
-            run_protocol_test "WebSocket" "$duration" "$parallel"
+            run_tcp_protocol_test "WebSocket" "$duration" "$parallel"
             ;;
-        full)
-            run_protocol_test "Auto" "$duration" "$parallel"
-            run_protocol_test "Http" "$duration" "$parallel"
-            run_protocol_test "WebSocket" "$duration" "$parallel"
+        websocket-reverse)
+            run_tcp_protocol_test "WebSocket" "$duration" "$parallel" "true"
+            ;;
+        udp-full)
+            run_udp_protocol_test "Auto" "$duration" "$bandwidth"
+            run_udp_protocol_test "Http" "$duration" "$bandwidth"
+            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth"
+            ;;
+        udp-full-reverse)
+            run_udp_protocol_test "Auto" "$duration" "$bandwidth" "true"
+            run_udp_protocol_test "Http" "$duration" "$bandwidth" "true"
+            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth" "true"
             ;;
         *)
             log_error "Unknown command: $command"

--- a/Projects/TutoProxy/scripts/perf-test.sh
+++ b/Projects/TutoProxy/scripts/perf-test.sh
@@ -21,6 +21,12 @@ SERVER_HTTP_PORT=5088
 DOCKER_NETWORK="tutoproxy-test"
 IPERF_SERVER_CONTAINER="iperf3-server"
 
+# Profiling
+PROFILE_MODE=false
+PROFILE_DIR=""
+SERVER_TRACE_PID=""
+CLIENT_TRACE_PID=""
+
 # Colors for output
 RED='\033[0;31m'
 GREEN='\033[0;32m'
@@ -41,6 +47,9 @@ log_error() {
 
 cleanup() {
     log_info "Cleaning up..."
+
+    # Stop profiling first
+    stop_profiling
 
     # Kill TutoProxy processes
     if [ -n "$SERVER_PID" ] && kill -0 "$SERVER_PID" 2>/dev/null; then
@@ -86,6 +95,88 @@ check_dependencies() {
     log_info "All dependencies OK"
 }
 
+check_profiling_tools() {
+    if [ "$PROFILE_MODE" = "true" ]; then
+        if ! command -v dotnet-trace &> /dev/null; then
+            log_error "dotnet-trace is not installed. Install with: dotnet tool install -g dotnet-trace"
+            exit 1
+        fi
+        log_info "Profiling tools OK"
+    fi
+}
+
+setup_profiling() {
+    if [ "$PROFILE_MODE" = "true" ]; then
+        PROFILE_DIR="$PROJECT_DIR/profiles/$(date +%Y%m%d_%H%M%S)"
+        mkdir -p "$PROFILE_DIR"
+        log_info "Profile output directory: $PROFILE_DIR"
+    fi
+}
+
+start_profiling() {
+    local test_name="$1"
+    if [ "$PROFILE_MODE" = "true" ] && [ -n "$SERVER_PID" ] && [ -n "$CLIENT_PID" ]; then
+        log_info "Starting profiling for: $test_name"
+
+        # Profile Server (dotnet-sampled-thread-time for CPU sampling)
+        dotnet-trace collect -p "$SERVER_PID" \
+            --output "$PROFILE_DIR/${test_name}_server.nettrace" \
+            --profile dotnet-sampled-thread-time &
+        SERVER_TRACE_PID=$!
+
+        # Profile Client
+        dotnet-trace collect -p "$CLIENT_PID" \
+            --output "$PROFILE_DIR/${test_name}_client.nettrace" \
+            --profile dotnet-sampled-thread-time &
+        CLIENT_TRACE_PID=$!
+
+        # Give trace time to attach
+        sleep 2
+    fi
+}
+
+stop_profiling() {
+    if [ "$PROFILE_MODE" = "true" ]; then
+        log_info "Stopping profiling..."
+
+        # Stop dotnet-trace processes - use SIGTERM, wait briefly, then force kill if needed
+        for trace_pid_var in SERVER_TRACE_PID CLIENT_TRACE_PID; do
+            eval "trace_pid=\$$trace_pid_var"
+            if [ -n "$trace_pid" ] && kill -0 "$trace_pid" 2>/dev/null; then
+                kill -TERM "$trace_pid" 2>/dev/null || true
+                # Wait up to 5 seconds for graceful shutdown
+                for i in 1 2 3 4 5; do
+                    if ! kill -0 "$trace_pid" 2>/dev/null; then
+                        break
+                    fi
+                    sleep 1
+                done
+                # Force kill if still running
+                if kill -0 "$trace_pid" 2>/dev/null; then
+                    kill -9 "$trace_pid" 2>/dev/null || true
+                fi
+                wait "$trace_pid" 2>/dev/null || true
+            fi
+            eval "$trace_pid_var=''"
+        done
+
+        log_info "Profiling stopped"
+    fi
+}
+
+convert_traces() {
+    if [ "$PROFILE_MODE" = "true" ] && [ -n "$PROFILE_DIR" ]; then
+        log_info "Converting traces to speedscope format..."
+        for trace in "$PROFILE_DIR"/*.nettrace; do
+            if [ -f "$trace" ]; then
+                dotnet-trace convert "$trace" --format speedscope 2>/dev/null || true
+            fi
+        done
+        log_info "Traces saved to: $PROFILE_DIR"
+        log_info "Open .speedscope.json files at https://www.speedscope.app/"
+    fi
+}
+
 build_projects() {
     log_info "Building TutoProxy projects..."
 
@@ -125,8 +216,9 @@ setup_docker() {
 start_tutoproxy_server() {
     log_info "Starting TutoProxy.Server on port $SERVER_HTTP_PORT (TCP+UDP:$TUNNEL_PORT)..."
 
-    dotnet run --project "$PROJECT_DIR/TutoProxy.Server/TutoProxy.Server.csproj" \
-        -c Release --no-build -- \
+    # Run DLL directly (not via 'dotnet run') so dotnet-trace can profile the actual app
+    local server_dll="$PROJECT_DIR/TutoProxy.Server/bin/Release/net10.0/TutoProxy.Server.dll"
+    dotnet "$server_dll" \
         "http://127.0.0.1:$SERVER_HTTP_PORT" \
         --tcp="$TUNNEL_PORT" \
         --udp="$TUNNEL_PORT" \
@@ -149,10 +241,9 @@ start_tutoproxy_client() {
     local protocol="${1:-Auto}"
     log_info "Starting TutoProxy.Client (protocol: $protocol, forwarding to Docker iperf3 at $IPERF_SERVER_IP)..."
 
-    # Client connects to our Server and forwards to iperf3 in Docker
-    # Using the Docker container's IP address
-    dotnet run --project "$PROJECT_DIR/TutoProxy.Client/TutoProxy.Client.csproj" \
-        -c Release --no-build -- \
+    # Run DLL directly (not via 'dotnet run') so dotnet-trace can profile the actual app
+    local client_dll="$PROJECT_DIR/TutoProxy.Client/bin/Release/net10.0/TutoProxy.Client.dll"
+    dotnet "$client_dll" \
         "http://127.0.0.1:$SERVER_HTTP_PORT" \
         "$IPERF_SERVER_IP" \
         --tcp="$TUNNEL_PORT" \
@@ -237,9 +328,11 @@ run_tcp_protocol_test() {
     local parallel="$3"
     local reverse="${4:-false}"
     local direction_label=""
+    local reverse_suffix=""
 
     if [ "$reverse" = "true" ]; then
         direction_label=" [REVERSE]"
+        reverse_suffix="_reverse"
     fi
 
     echo ""
@@ -250,8 +343,11 @@ run_tcp_protocol_test() {
     start_tutoproxy_server
     start_tutoproxy_client "$protocol"
 
+    start_profiling "tcp_${protocol}${reverse_suffix}"
+
     run_iperf_tcp_test "$duration" "$parallel" "$reverse"
 
+    stop_profiling
     stop_tutoproxy
 }
 
@@ -261,9 +357,11 @@ run_udp_protocol_test() {
     local bandwidth="$3"
     local reverse="${4:-false}"
     local direction_label=""
+    local reverse_suffix=""
 
     if [ "$reverse" = "true" ]; then
         direction_label=" [REVERSE]"
+        reverse_suffix="_reverse"
     fi
 
     echo ""
@@ -274,8 +372,11 @@ run_udp_protocol_test() {
     start_tutoproxy_server
     start_tutoproxy_client "$protocol"
 
+    start_profiling "udp_${protocol}${reverse_suffix}"
+
     run_iperf_udp_test "$duration" "$bandwidth" "$reverse"
 
+    stop_profiling
     stop_tutoproxy
 }
 
@@ -296,11 +397,13 @@ print_usage() {
     echo "  -d, --duration    Test duration in seconds (default: 10)"
     echo "  -p, --parallel    Number of parallel TCP streams (default: 1)"
     echo "  -b, --bandwidth   UDP bandwidth limit (default: 100M)"
+    echo "  --profile         Enable CPU profiling with dotnet-trace"
     echo ""
     echo "Examples:"
     echo "  $0 full"
     echo "  $0 full-reverse"
     echo "  $0 websocket -d 30 -p 4"
+    echo "  $0 websocket --profile -d 30"
     echo "  $0 udp-full -d 10 -b 1000M"
 }
 
@@ -326,6 +429,10 @@ main() {
                 bandwidth="$2"
                 shift 2
                 ;;
+            --profile)
+                PROFILE_MODE=true
+                shift
+                ;;
             -h|--help)
                 print_usage
                 exit 0
@@ -339,8 +446,10 @@ main() {
     done
 
     check_dependencies
+    check_profiling_tools
     build_projects
     setup_docker
+    setup_profiling
 
     case $command in
         full)
@@ -376,6 +485,7 @@ main() {
             ;;
     esac
 
+    convert_traces
     log_info "Test complete!"
 }
 

--- a/Projects/TutoProxy/scripts/perf-test.sh
+++ b/Projects/TutoProxy/scripts/perf-test.sh
@@ -239,7 +239,8 @@ start_tutoproxy_server() {
 
 start_tutoproxy_client() {
     local protocol="${1:-Auto}"
-    log_info "Starting TutoProxy.Client (protocol: $protocol, forwarding to Docker iperf3 at $IPERF_SERVER_IP)..."
+    local signalr_parallel="${2:-1}"
+    log_info "Starting TutoProxy.Client (protocol: $protocol, parallel: $signalr_parallel, forwarding to Docker iperf3 at $IPERF_SERVER_IP)..."
 
     # Run DLL directly (not via 'dotnet run') so dotnet-trace can profile the actual app
     local client_dll="$PROJECT_DIR/TutoProxy.Client/bin/Release/net10.0/TutoProxy.Client.dll"
@@ -250,12 +251,14 @@ start_tutoproxy_client() {
         --udp="$TUNNEL_PORT" \
         --id="PerfTestClient" \
         --protocol="$protocol" \
+        --parallel="$signalr_parallel" \
         --daemon &
 
     CLIENT_PID=$!
 
-    # Wait for client to connect
-    sleep 3
+    # Wait for client to connect (more time for parallel connections)
+    local wait_time=$((3 + signalr_parallel))
+    sleep "$wait_time"
 
     if ! kill -0 "$CLIENT_PID" 2>/dev/null; then
         log_error "TutoProxy.Client failed to start"
@@ -325,8 +328,9 @@ run_iperf_udp_test() {
 run_tcp_protocol_test() {
     local protocol="$1"
     local duration="$2"
-    local parallel="$3"
-    local reverse="${4:-false}"
+    local iperf_parallel="$3"
+    local signalr_parallel="$4"
+    local reverse="${5:-false}"
     local direction_label=""
     local reverse_suffix=""
 
@@ -338,14 +342,15 @@ run_tcp_protocol_test() {
     echo ""
     echo "========================================="
     echo "  TCP TUNNEL TEST ($protocol)$direction_label"
+    echo "  iperf3 streams: $iperf_parallel, SignalR connections: $signalr_parallel"
     echo "========================================="
 
     start_tutoproxy_server
-    start_tutoproxy_client "$protocol"
+    start_tutoproxy_client "$protocol" "$signalr_parallel"
 
     start_profiling "tcp_${protocol}${reverse_suffix}"
 
-    run_iperf_tcp_test "$duration" "$parallel" "$reverse"
+    run_iperf_tcp_test "$duration" "$iperf_parallel" "$reverse"
 
     stop_profiling
     stop_tutoproxy
@@ -355,7 +360,8 @@ run_udp_protocol_test() {
     local protocol="$1"
     local duration="$2"
     local bandwidth="$3"
-    local reverse="${4:-false}"
+    local signalr_parallel="$4"
+    local reverse="${5:-false}"
     local direction_label=""
     local reverse_suffix=""
 
@@ -367,10 +373,11 @@ run_udp_protocol_test() {
     echo ""
     echo "========================================="
     echo "  UDP TUNNEL TEST ($protocol)$direction_label"
+    echo "  SignalR connections: $signalr_parallel"
     echo "========================================="
 
     start_tutoproxy_server
-    start_tutoproxy_client "$protocol"
+    start_tutoproxy_client "$protocol" "$signalr_parallel"
 
     start_profiling "udp_${protocol}${reverse_suffix}"
 
@@ -394,15 +401,17 @@ print_usage() {
     echo "  udp-full-reverse  Run full UDP test in reverse direction"
     echo ""
     echo "Options:"
-    echo "  -d, --duration    Test duration in seconds (default: 10)"
-    echo "  -p, --parallel    Number of parallel TCP streams (default: 1)"
-    echo "  -b, --bandwidth   UDP bandwidth limit (default: 100M)"
-    echo "  --profile         Enable CPU profiling with dotnet-trace"
+    echo "  -d, --duration       Test duration in seconds (default: 10)"
+    echo "  -p, --parallel       Number of parallel iperf3 TCP streams (default: 1)"
+    echo "  -s, --signalr-parallel  Number of parallel SignalR connections (default: 1)"
+    echo "  -b, --bandwidth      UDP bandwidth limit (default: 100M)"
+    echo "  --profile            Enable CPU profiling with dotnet-trace"
     echo ""
     echo "Examples:"
     echo "  $0 full"
     echo "  $0 full-reverse"
     echo "  $0 websocket -d 30 -p 4"
+    echo "  $0 websocket -d 30 -p 4 -s 4    # 4 iperf streams over 4 SignalR connections"
     echo "  $0 websocket --profile -d 30"
     echo "  $0 udp-full -d 10 -b 1000M"
 }
@@ -412,7 +421,8 @@ main() {
     shift || true
 
     local duration=10
-    local parallel=1
+    local iperf_parallel=1
+    local signalr_parallel=1
     local bandwidth="100M"
 
     while [[ $# -gt 0 ]]; do
@@ -422,7 +432,11 @@ main() {
                 shift 2
                 ;;
             -p|--parallel)
-                parallel="$2"
+                iperf_parallel="$2"
+                shift 2
+                ;;
+            -s|--signalr-parallel)
+                signalr_parallel="$2"
                 shift 2
                 ;;
             -b|--bandwidth)
@@ -453,30 +467,30 @@ main() {
 
     case $command in
         full)
-            run_tcp_protocol_test "Auto" "$duration" "$parallel"
-            run_tcp_protocol_test "Http" "$duration" "$parallel"
-            run_tcp_protocol_test "WebSocket" "$duration" "$parallel"
+            run_tcp_protocol_test "Auto" "$duration" "$iperf_parallel" "$signalr_parallel"
+            run_tcp_protocol_test "Http" "$duration" "$iperf_parallel" "$signalr_parallel"
+            run_tcp_protocol_test "WebSocket" "$duration" "$iperf_parallel" "$signalr_parallel"
             ;;
         full-reverse)
-            run_tcp_protocol_test "Auto" "$duration" "$parallel" "true"
-            run_tcp_protocol_test "Http" "$duration" "$parallel" "true"
-            run_tcp_protocol_test "WebSocket" "$duration" "$parallel" "true"
+            run_tcp_protocol_test "Auto" "$duration" "$iperf_parallel" "$signalr_parallel" "true"
+            run_tcp_protocol_test "Http" "$duration" "$iperf_parallel" "$signalr_parallel" "true"
+            run_tcp_protocol_test "WebSocket" "$duration" "$iperf_parallel" "$signalr_parallel" "true"
             ;;
         websocket)
-            run_tcp_protocol_test "WebSocket" "$duration" "$parallel"
+            run_tcp_protocol_test "WebSocket" "$duration" "$iperf_parallel" "$signalr_parallel"
             ;;
         websocket-reverse)
-            run_tcp_protocol_test "WebSocket" "$duration" "$parallel" "true"
+            run_tcp_protocol_test "WebSocket" "$duration" "$iperf_parallel" "$signalr_parallel" "true"
             ;;
         udp-full)
-            run_udp_protocol_test "Auto" "$duration" "$bandwidth"
-            run_udp_protocol_test "Http" "$duration" "$bandwidth"
-            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth"
+            run_udp_protocol_test "Auto" "$duration" "$bandwidth" "$signalr_parallel"
+            run_udp_protocol_test "Http" "$duration" "$bandwidth" "$signalr_parallel"
+            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth" "$signalr_parallel"
             ;;
         udp-full-reverse)
-            run_udp_protocol_test "Auto" "$duration" "$bandwidth" "true"
-            run_udp_protocol_test "Http" "$duration" "$bandwidth" "true"
-            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth" "true"
+            run_udp_protocol_test "Auto" "$duration" "$bandwidth" "$signalr_parallel" "true"
+            run_udp_protocol_test "Http" "$duration" "$bandwidth" "$signalr_parallel" "true"
+            run_udp_protocol_test "WebSocket" "$duration" "$bandwidth" "$signalr_parallel" "true"
             ;;
         *)
             log_error "Unknown command: $command"

--- a/README.md
+++ b/README.md
@@ -174,17 +174,17 @@ The project includes a performance testing script that measures tunnel throughpu
 #### Usage
 
 ```bash
-# Full test (Auto + Http + WebSocket protocols)
+# Full TCP test (Auto + Http + WebSocket protocols)
 ./Projects/TutoProxy/scripts/perf-test.sh full
+./Projects/TutoProxy/scripts/perf-test.sh full-reverse
 
-# WebSocket protocol test (fastest, skips negotiation)
+# WebSocket protocol test (fastest)
 ./Projects/TutoProxy/scripts/perf-test.sh websocket -d 10
+./Projects/TutoProxy/scripts/perf-test.sh websocket-reverse -d 10
 
-# Auto protocol test with parallel streams
-./Projects/TutoProxy/scripts/perf-test.sh auto -d 30 -p 4
-
-# Http protocol test (LongPolling)
-./Projects/TutoProxy/scripts/perf-test.sh http -d 10
+# Full UDP test (Auto + Http + WebSocket protocols)
+./Projects/TutoProxy/scripts/perf-test.sh udp-full -d 10 -b 1000M
+./Projects/TutoProxy/scripts/perf-test.sh udp-full-reverse -d 10 -b 1000M
 ```
 
 #### VSCode Tasks

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ TutoProxy.Server http://200.100.10.1:8088 \
 | `--tcp <ports>` | No* | TCP ports to handle. Must be subset of server's TCP ports. Example: `--tcp=80,443` |
 | `--udp <ports>` | No* | UDP ports to handle. Must be subset of server's UDP ports. Example: `--udp=5000-5005` |
 | `--protocol <mode>` | No | Transport protocol: `Auto` (default), `Http`, `WebSocket`. WebSocket mode skips negotiation for faster connection |
+| `--parallel <count>` | No | Number of parallel SignalR connections (1-8, default: 1). Multiple connections increase throughput by distributing TCP sessions across channels |
 | `--daemon` | No | Run in daemon mode without terminal GUI, reduces CPU overhead |
 
 *At least one of `--tcp` or `--udp` must be specified.
@@ -63,78 +64,83 @@ TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 \
     --id=Client0Linux
 ```
 
+**Example - start client with 4 parallel SignalR connections for higher throughput:**
+
+```bash
+TutoProxy.Client http://200.100.10.1:8088 127.0.0.1 \
+    --tcp=8071-8080 \
+    --id=Client0Linux \
+    --protocol=WebSocket \
+    --parallel=4
+```
+
 **Important:** Ports of different TutoProxy.Client instances must not overlap. Each client serves a unique set of ports.
 
 ---
 
 ### Traffic Flow Architecture
 
+#### Parallel SignalR Connections
+
+TutoProxy.Client supports multiple parallel SignalR connections to increase throughput. When `--parallel=N` is specified:
+- Client creates N `SignalRConnection` instances to the server
+- Server groups these connections into a `ClientGroup`
+- New TCP sessions are distributed across connections using round-robin
+- Each TCP session maintains affinity to its assigned connection (session stickiness)
+- UDP traffic is distributed across connections using round-robin
+
 #### Request Flow (External Client -> Target Host)
 
-```
-┌─────────────┐      ┌─────────────────────────────────────────────┐      ┌─────────────────────────────────────────┐       ┌─────────────┐
-│  EXTERNAL   │      │               TUTOPROXY.SERVER              │      │           TUTOPROXY.CLIENT              │       │   TARGET    │
-│   CLIENT    │      │                                             │      │                                         │       │    HOST     │
-└──────┬──────┘      └─────────────────────────────────────────────┘      └─────────────────────────────────────────┘       └──────▲──────┘
-       │                                                                                                                           │
-       │  ┌──────────┐  ┌──────────┐  ┌────────────────────┐  ┌───────────┐        ┌──────────────┐  ┌──────────────┐  ┌──────────┐│
-       └─►│TcpServer │─►│TcpClient │─►│DataTransferService │─►│SignalRHub │───────►│SignalRClient │─►│ClientsService│─►│TcpClient │┘
-          │UdpServer │  │UdpClient │  │                    │  │           │SignalR │              │  │              │  │UdpClient │
-          └──────────┘  └──────────┘  └────────────────────┘  └───────────┘        └──────────────┘  └──────────────┘  └──────────┘
-```
-
 **TutoProxy.Server side:**
-1. External Client sends data to TutoProxy.Server
-2. `TcpServer` / `UdpServer` receives incoming data
-3. `TcpServer` / `UdpServer` passes data to `TcpClient` / `UdpClient`
-4. `TcpClient` / `UdpClient` sends data via `DataTransferService` to `SignalRHub`
+1. External Client connects to `TcpServer.Listen()` / `UdpServer`
+2. `TcpServer` calls `DataTransferService.ConnectTcp()` to establish session
+3. `DataTransferService` selects connection via `HubClientsService.GetConnectionIdForTcp()` (round-robin)
+4. `DataTransferService` registers session affinity via `HubClientsService.RegisterTcpSession()`
+5. `DataTransferService` invokes `ConnectTcp` on selected `SignalRConnection`
+6. On data receive, `TcpClient.ReceivingStream()` calls `DataTransferService.SendTcpRequest()`
+7. `DataTransferService` uses `HubClientsService.GetConnectionIdForTcpSession()` for session affinity
+8. `DataTransferService` invokes `TcpRequest` on the same connection
 
 **TutoProxy.Client side:**
-1. `SignalRClient` receives `TcpRequest` / `UdpRequest` and passes to `TcpClient` / `UdpClient`
-2. `TcpClient` / `UdpClient` sends data to Target Host
+1. `ClientReceiver.ConnectTcp()` receives connection request
+2. `ClientsService.AddTcpClient()` creates `TcpClient` with specific `ITcpDataChannel`
+3. `TcpClient.Connect()` establishes socket to Target Host
+4. `ClientReceiver.TcpRequest()` receives data, passes to `TcpClient.SendRequest()`
+5. `TcpClient` sends data to Target Host via socket
 
 #### Response Flow (Target Host -> External Client)
 
-```
-┌─────────────┐      ┌─────────────────────────────────────────────┐      ┌─────────────────────────────────────────┐       ┌─────────────┐
-│  EXTERNAL   │      │               TUTOPROXY.SERVER              │      │           TUTOPROXY.CLIENT              │       │   TARGET    │
-│   CLIENT    │      │                                             │      │                                         │       │    HOST     │
-└──────▲──────┘      └─────────────────────────────────────────────┘      └─────────────────────────────────────────┘       └──────┬──────┘
-       │                                                                                                                           │
-       │  ┌──────────┐  ┌──────────┐  ┌────────────────────┐  ┌───────────┐        ┌──────────────┐                    ┌──────────┐│
-       └──│TcpServer │◄─│TcpClient │◄─│DataTransferService │◄─│SignalRHub │◄───────│SignalRClient │◄───────────────────│TcpClient │┘
-          │UdpServer │  │UdpClient │  │                    │  │           │SignalR │              │                    │UdpClient │
-          └──────────┘  └──────────┘  └────────────────────┘  └───────────┘        └──────────────┘                    └──────────┘
-
-```
-
 **TutoProxy.Client side:**
 1. Target Host sends response data
-2. `TcpClient` / `UdpClient` receives response
-3. `TcpClient` / `UdpClient` passes response to `SignalRClient` (`SendTcpResponse` / `SendUdpResponse`)
-4. `SignalRClient` sends data to TutoProxy.Server
+2. `TcpClient.ReceivingStream()` receives data from socket
+3. `TcpClient` calls `ITcpDataChannel.SendTcpResponse()` (bound to specific `SignalRConnection`)
+4. `SignalRConnection.SendTcpResponse()` invokes `hubProxy.TcpResponse()`
 
 **TutoProxy.Server side:**
-1. `SignalRHub` receives `TcpResponse` / `UdpResponse`
-2. `DataTransferService` finds corresponding `HubClient` and passes response to it
-3. `HubClient` finds `TcpServer` / `UdpServer` by port
-4. `TcpServer` / `UdpServer` finds `TcpClient` / `UdpClient` by origin port
-5. `TcpClient` / `UdpClient` sends response via socket to External Client
+1. `SignalRHub.TcpResponse()` receives response with `Context.ConnectionId`
+2. `SignalRHub` calls `DataTransferService.HandleTcpResponse()`
+3. `DataTransferService` calls `HubClientsService.GetClient()` to find `HubClient`
+4. `HubClient.SendTcpResponse()` finds `TcpServer` by port
+5. `TcpServer.SendResponse()` finds `TcpClient` by origin port
+6. `TcpClient.SendDataAsync()` sends response via socket to External Client
 
 #### Component Responsibilities
 
 **TutoProxy.Server:**
-- `SignalRHub` - SignalR hub, communication with TutoProxy.Client
-- `DataTransferService` - routes data between SignalRHub and HubClients
-- `HubClient` - represents connected TutoProxy.Client, contains TcpServers/UdpServers
-- `TcpServer` / `UdpServer` - listen on ports, manage client sessions
-- `TcpClient` / `UdpClient` - handle individual external client sessions
-- `HubClientsService` - manage HubClient instances, validate ports and client IDs
+- `SignalRHub` - SignalR hub, handles `TcpResponse`, `UdpResponse`, `DisconnectTcp`, `DisconnectUdp`
+- `HubClientsService` - manages `ClientGroup` instances, handles parallel connections, round-robin distribution, session affinity
+- `ClientGroup` - groups SignalR connections from same client, contains `HubClient` and connection list
+- `DataTransferService` - routes data between SignalRHub and HubClients, manages session registration
+- `HubClient` - represents connected TutoProxy.Client, contains `TcpServer`/`UdpServer` instances
+- `TcpServer` / `UdpServer` - listen on ports, manage `TcpClient`/`UdpClient` sessions
+- `TcpClient` / `UdpClient` - handle individual external client socket sessions
 
 **TutoProxy.Client:**
-- `SignalRClient` - connection to TutoProxy.Server, receives requests, sends responses
-- `TcpClient` / `UdpClient` - connect to target host, forward data
-- `ClientsService` - manage active connections
+- `SignalRClient` - manages multiple `SignalRConnection` instances for parallel connections
+- `SignalRConnection` - implements `ITcpDataChannel`, wraps `HubConnection`, handles TCP session affinity
+- `ClientReceiver` - implements `IClientReceiver`, handles incoming `TcpRequest`, `UdpRequest`, `ConnectTcp`
+- `TcpClient` / `UdpClient` - connect to target host, send requests, receive responses via bound `ITcpDataChannel`
+- `ClientsService` - manages active `TcpClient`/`UdpClient` instances
 
 ---
 
@@ -181,6 +187,9 @@ The project includes a performance testing script that measures tunnel throughpu
 # WebSocket protocol test (fastest)
 ./Projects/TutoProxy/scripts/perf-test.sh websocket -d 10
 ./Projects/TutoProxy/scripts/perf-test.sh websocket-reverse -d 10
+
+# Parallel connections test (4 iperf streams over 4 SignalR connections)
+./Projects/TutoProxy/scripts/perf-test.sh websocket -d 10 -p 4 -s 4
 
 # Full UDP test (Auto + Http + WebSocket protocols)
 ./Projects/TutoProxy/scripts/perf-test.sh udp-full -d 10 -b 1000M

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ TutoProxy.Server http://200.100.10.1:8088 \
 |----------|----------|-------------|
 | `<server>` | Yes | TutoProxy.Server address. Example: `http://200.100.10.1:8088` |
 | `<sendto>` | Yes | Target host IP where traffic will be forwarded. Example: `127.0.0.1` or `192.168.1.100` |
-| `--id <id>` | Yes | Unique client identifier. Must match allowed clients on server if restriction is enabled |
+| `--id <id>` | No  | Unique client identifier. Must match allowed clients on server if restriction is enabled |
 | `--tcp <ports>` | No* | TCP ports to handle. Must be subset of server's TCP ports. Example: `--tcp=80,443` |
 | `--udp <ports>` | No* | UDP ports to handle. Must be subset of server's UDP ports. Example: `--udp=5000-5005` |
 | `--protocol <mode>` | No | Transport protocol: `Auto` (default), `Http`, `WebSocket`. WebSocket mode skips negotiation for faster connection |


### PR DESCRIPTION
This PR introduces parallel SignalR connection support to significantly improve TCP throughput performance. The implementation allows TutoProxy.Client to establish multiple concurrent connections to the server, distributing TCP sessions across channels while maintaining session affinity.

### Key Changes

#### 1. Parallel SignalR Connection Architecture

Implemented multi-connection support on both client and server sides to increase throughput by distributing TCP sessions across multiple SignalR channels.

**Key files**: `TutoProxy.Server/Services/HubClientsService.cs`, `TutoProxy.Client/Communication/SignalRClient.cs`

-   Added  `ClientGroup`  class to manage multiple SignalR connections from the same client
-   Implemented round-robin distribution for new TCP sessions via  `GetNextConnectionId()`
-   Added session stickiness via  `tcpSessionToConnectionId`  dictionary to maintain affinity
-   New query parameters:  `ConnectionIndex`  and  `TotalConnections`  for connection coordination

```csharp
// Client specifies connection index and total count
query = QueryString.Create([
    KeyValuePair.Create(SignalRParams.ConnectionIndex, i.ToString()),
    KeyValuePair.Create(SignalRParams.TotalConnections, parallelCount.ToString())
]);

```

#### 2. TCP Session Channel Interface

Introduced `ITcpDataChannel` abstraction for proper session-to-connection binding.

**Key files**: `TutoProxy.Client/Communication/ITcpDataChannel.cs`, `TutoProxy.Client/Communication/SignalRClient.cs`

-   Each  `TcpClient`  now receives specific  `ITcpDataChannel`  for its session
-   `SignalRConnection`  implements  `ITcpDataChannel`  for direct channel communication
-   `TcpChannelWrapper`  allows deferred channel assignment

#### 3. Object Pooling for Data Models

Added `ObjectPool` pattern for data transfer models to reduce GC pressure in hot paths.

**Key files**: `TuToProxy.Core/Pooling/DataModelPool.cs`, `TuToProxy.Core/Models/DataBaseModel.cs`

```csharp
public static class DataModelPool<T> where T : DataBaseModel, new() {
    static readonly ObjectPool<T> pool =
        new DefaultObjectPoolProvider().Create(new DataModelPoolPolicy<T>());

    public static T Rent() => pool.Get();
    public static void Return(T model) { model.Reset(); pool.Return(model); }
}

```

#### 4. Performance Optimizations

-   Removed logging from hot paths to reduce overhead
-   Added  `--parallel <count>`  CLI option (1-8 connections, default: 1)

**Key files**: `TutoProxy.Client/CommandLine/AppRootCommand.cs`

#### 5. Refactoring

-   Migrated  `System.CommandLine`  from 2.0.0-beta3 to 2.0.3
-   Updated NuGet packages across all projects
-   Made  `--id`  client argument optional
-   Improved string nullability handling
-   Refactored query parameter creation

**Key files**: `TutoProxy.Client/Program.cs`, `TutoProxy.Server/Program.cs`, various `AppRootCommand.cs` files

#### 6. Tests

-   Added  `DataModelPoolTests`  for object pooling verification
-   Added reverse traffic performance tests to  `perf-test.sh`
-   Updated  `HubClientsServiceTests`  for multi-connection scenarios
-   Added profiling support (`--profile`  flag) to performance test script
-   Updated CI workflow to run reverse traffic performance tests

**Key files**: `TuToProxy.Core.Tests/PoolingTests/DataModelPoolTests.cs`, `TutoProxy.Server.Tests/Services/HubClientsServiceTests.cs`, `scripts/perf-test.sh`

#### 7. Documentation

-   Updated  `README.md`  with parallel connections architecture
-   Added Traffic Flow Architecture section explaining connection distribution
-   Added example for  `--parallel`  option usage